### PR TITLE
feat: add enhanced useBraces modes, structural indentation, and nextControlFlowPosition fixes

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -151,6 +151,24 @@
       }, {
         "const": "preferNone",
         "description": "Forces no braces when the header is one line and body is one line. Otherwise forces braces."
+      }, {
+        "const": "whenNeeded",
+        "description": "Uses braces when needed for clarity or safety, avoiding them when the statement is simple and unambiguous."
+      }, {
+        "const": "whenFormattedMultiLine",
+        "description": "Uses braces when the formatted code spans multiple lines, removing them for single-line statements."
+      }]
+    },
+    "ternaryIndentStyle": {
+      "description": "How ternary conditional expressions should be indented.",
+      "type": "string",
+      "default": "align",
+      "oneOf": [{
+        "const": "align",
+        "description": "Align the ? and : operators under the condition."
+      }, {
+        "const": "structural",
+        "description": "Use structural indentation for the ternary expression."
       }]
     },
     "bracePosition": {
@@ -199,6 +217,9 @@
       }, {
         "const": "nextLine",
         "description": "Forces the next control flow to be on the next line."
+      }, {
+        "const": "nextLineExceptAfterBrace",
+        "description": "Forces the next control flow to be on the next line, except when preceded by a brace."
       }]
     },
     "trailingCommas": {
@@ -1180,6 +1201,14 @@
     },
     "conditionalExpression.operatorPosition": {
       "$ref": "#/definitions/operatorPosition"
+    },
+    "conditionalExpression.indentStyle": {
+      "$ref": "#/definitions/ternaryIndentStyle"
+    },
+    "expressionStatement.forceParentheses": {
+      "description": "Whether to force parentheses around expression statements.",
+      "type": "boolean",
+      "default": true
     },
     "conditionalType.operatorPosition": {
       "$ref": "#/definitions/operatorPosition"

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -822,6 +822,10 @@ impl ConfigurationBuilder {
     self.insert("conditionalExpression.operatorPosition", value.to_string().into())
   }
 
+  pub fn conditional_expression_indent_style(&mut self, value: TernaryIndentStyle) -> &mut Self {
+    self.insert("conditionalExpression.indentStyle", value.to_string().into())
+  }
+
   pub fn conditional_type_operator_position(&mut self, value: OperatorPosition) -> &mut Self {
     self.insert("conditionalType.operatorPosition", value.to_string().into())
   }
@@ -1075,6 +1079,10 @@ impl ConfigurationBuilder {
 
   pub fn while_statement_space_around(&mut self, value: bool) -> &mut Self {
     self.insert("whileStatement.spaceAround", value.into())
+  }
+
+  pub fn expression_statement_force_parentheses(&mut self, value: bool) -> &mut Self {
+    self.insert("expressionStatement.forceParentheses", value.into())
   }
 
   #[cfg(test)]

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -202,6 +202,7 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
     /* operator position */
     binary_expression_operator_position: get_value(&mut config, "binaryExpression.operatorPosition", operator_position, &mut diagnostics),
     conditional_expression_operator_position: get_value(&mut config, "conditionalExpression.operatorPosition", operator_position, &mut diagnostics),
+    conditional_expression_indent_style: get_value(&mut config, "conditionalExpression.indentStyle", TernaryIndentStyle::Align, &mut diagnostics),
     conditional_type_operator_position: get_value(&mut config, "conditionalType.operatorPosition", operator_position, &mut diagnostics),
     /* single body position */
     if_statement_single_body_position: get_value(&mut config, "ifStatement.singleBodyPosition", single_body_position, &mut diagnostics),
@@ -333,6 +334,7 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
     switch_statement_space_around: get_value(&mut config, "switchStatement.spaceAround", space_around, &mut diagnostics),
     tuple_type_space_around: get_value(&mut config, "tupleType.spaceAround", space_around, &mut diagnostics),
     while_statement_space_around: get_value(&mut config, "whileStatement.spaceAround", space_around, &mut diagnostics),
+    expression_statement_force_parentheses: get_value(&mut config, "expressionStatement.forceParentheses", true, &mut diagnostics),
   };
 
   diagnostics.extend(get_unknown_property_diagnostics(config));

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -119,9 +119,11 @@ pub enum NextControlFlowPosition {
   SameLine,
   /// Forces the next control flow to be on the next line.
   NextLine,
+  /// Forces the next control flow to be on the next line except when it appears after a closing brace.
+  NextLineExceptAfterBrace,
 }
 
-generate_str_to_from![NextControlFlowPosition, [Maintain, "maintain"], [SameLine, "sameLine"], [NextLine, "nextLine"]];
+generate_str_to_from![NextControlFlowPosition, [Maintain, "maintain"], [SameLine, "sameLine"], [NextLine, "nextLine"], [NextLineExceptAfterBrace, "nextLineExceptAfterBrace"]];
 
 /// Where to place the operator for expressions that span multiple lines.
 #[derive(Debug, Clone, PartialEq, Copy, Serialize, Deserialize)]
@@ -136,6 +138,19 @@ pub enum OperatorPosition {
 }
 
 generate_str_to_from![OperatorPosition, [Maintain, "maintain"], [SameLine, "sameLine"], [NextLine, "nextLine"]];
+
+/// How to indent ternary expression branches.
+#[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TernaryIndentStyle {
+  /// Align all ternary branches at the same indentation level (original behavior).
+  Align,
+  /// Add structural indentation for nested ternary branches.
+  Structural,
+}
+
+generate_str_to_from![TernaryIndentStyle, [Align, "align"], [Structural, "structural"]];
+
 
 /// Where to place a node that could be on the same line or next line.
 #[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
@@ -163,6 +178,10 @@ pub enum UseBraces {
   Always,
   /// Forces no braces when the header is one line and body is one line. Otherwise forces braces.
   PreferNone,
+  /// Only uses braces when syntactically required (empty blocks, declarations, multiple statements).
+  WhenNeeded,
+  /// Uses braces when the formatted body spans multiple lines.
+  WhenFormattedMultiLine,
 }
 
 generate_str_to_from![
@@ -170,7 +189,9 @@ generate_str_to_from![
   [Maintain, "maintain"],
   [WhenNotSingleLine, "whenNotSingleLine"],
   [Always, "always"],
-  [PreferNone, "preferNone"]
+  [PreferNone, "preferNone"],
+  [WhenNeeded, "whenNeeded"],
+  [WhenFormattedMultiLine, "whenFormattedMultiLine"]
 ];
 
 /// Whether to use parentheses around a single parameter in an arrow function.
@@ -466,6 +487,8 @@ pub struct Configuration {
   pub binary_expression_operator_position: OperatorPosition,
   #[serde(rename = "conditionalExpression.operatorPosition")]
   pub conditional_expression_operator_position: OperatorPosition,
+  #[serde(rename = "conditionalExpression.indentStyle")]
+  pub conditional_expression_indent_style: TernaryIndentStyle,
   #[serde(rename = "conditionalType.operatorPosition")]
   pub conditional_type_operator_position: OperatorPosition,
   /* single body position */
@@ -662,4 +685,7 @@ pub struct Configuration {
   pub tuple_type_space_around: bool,
   #[serde(rename = "whileStatement.spaceAround")]
   pub while_statement_space_around: bool,
+  /* expression parentheses */
+  #[serde(rename = "expressionStatement.forceParentheses")]
+  pub expression_statement_force_parentheses: bool,
 }

--- a/tests/specs/expressions/ConditionalExpression/ConditionalExpression_IndentStyle_Align.txt
+++ b/tests/specs/expressions/ConditionalExpression/ConditionalExpression_IndentStyle_Align.txt
@@ -1,0 +1,82 @@
+~~ conditionalExpression.indentStyle: align ~~
+== should handle simple ternary with align indentation ==
+const result = condition
+  ? value1
+  : value2;
+
+[expect]
+const result = condition
+    ? value1
+    : value2;
+
+== should handle nested ternary with align indentation ==
+const result = condition1
+  ? value1
+  : condition2
+  ? value2
+  : condition3
+  ? value3
+  : value4;
+
+[expect]
+const result = condition1
+    ? value1
+    : condition2
+    ? value2
+    : condition3
+    ? value3
+    : value4;
+
+== should handle deeply nested ternary ==
+const test = this.log(`long text here`)
+  ? this.log(`another long text`)
+  : this.log(`third long text`)
+  ? this.log(`fourth long text`)
+  ? this.log(`fifth long text`)
+  : this.log(`sixth long text`)
+  : this.log(`seventh long text`);
+
+[expect]
+const test = this.log(`long text here`)
+    ? this.log(`another long text`)
+    : this.log(`third long text`)
+    ? this.log(`fourth long text`)
+        ? this.log(`fifth long text`)
+        : this.log(`sixth long text`)
+    : this.log(`seventh long text`);
+
+== should handle ternary with function calls ==
+const value = isValid(data)
+  ? processData(data)
+  : hasFallback(data)
+  ? getFallback(data)
+  : getDefault();
+
+[expect]
+const value = isValid(data)
+    ? processData(data)
+    : hasFallback(data)
+    ? getFallback(data)
+    : getDefault();
+
+== should handle ternary in else branch ==
+if (condition) {
+  doSomething();
+} else {
+  const result = check1
+    ? value1
+    : check2
+    ? value2
+    : value3;
+}
+
+[expect]
+if (condition) {
+    doSomething();
+} else {
+    const result = check1
+        ? value1
+        : check2
+        ? value2
+        : value3;
+}

--- a/tests/specs/expressions/ConditionalExpression/ConditionalExpression_IndentStyle_Structural.txt
+++ b/tests/specs/expressions/ConditionalExpression/ConditionalExpression_IndentStyle_Structural.txt
@@ -1,0 +1,82 @@
+~~ conditionalExpression.indentStyle: structural ~~
+== should handle simple ternary with structural indentation ==
+const result = condition
+  ? value1
+  : value2;
+
+[expect]
+const result = condition
+    ? value1
+    : value2;
+
+== should handle nested ternary with structural indentation ==
+const result = condition1
+  ? value1
+  : condition2
+  ? value2
+  : condition3
+  ? value3
+  : value4;
+
+[expect]
+const result = condition1
+    ? value1
+    : condition2
+        ? value2
+        : condition3
+            ? value3
+            : value4;
+
+== should handle deeply nested ternary ==
+const test = this.log(`long text here`)
+  ? this.log(`another long text`)
+  : this.log(`third long text`)
+  ? this.log(`fourth long text`)
+  ? this.log(`fifth long text`)
+  : this.log(`sixth long text`)
+  : this.log(`seventh long text`);
+
+[expect]
+const test = this.log(`long text here`)
+    ? this.log(`another long text`)
+    : this.log(`third long text`)
+        ? this.log(`fourth long text`)
+            ? this.log(`fifth long text`)
+            : this.log(`sixth long text`)
+        : this.log(`seventh long text`);
+
+== should handle ternary with function calls ==
+const value = isValid(data)
+  ? processData(data)
+  : hasFallback(data)
+  ? getFallback(data)
+  : getDefault();
+
+[expect]
+const value = isValid(data)
+    ? processData(data)
+    : hasFallback(data)
+        ? getFallback(data)
+        : getDefault();
+
+== should handle ternary in else branch ==
+if (condition) {
+  doSomething();
+} else {
+  const result = check1
+    ? value1
+    : check2
+    ? value2
+    : value3;
+}
+
+[expect]
+if (condition) {
+    doSomething();
+} else {
+    const result = check1
+        ? value1
+        : check2
+            ? value2
+            : value3;
+}

--- a/tests/specs/statements/doWhileStatement/DoWhileStatement_NextControlFlowPosition_NextLineExceptAfterBrace.txt
+++ b/tests/specs/statements/doWhileStatement/DoWhileStatement_NextControlFlowPosition_NextLineExceptAfterBrace.txt
@@ -1,0 +1,17 @@
+~~ doWhileStatement.nextControlFlowPosition: nextLineExceptAfterBrace ~~
+== should keep while on same line after brace ==
+do {
+    doSomething();
+} while (condition);
+
+[expect]
+do {
+    doSomething();
+} while (condition);
+
+== should use newline before while for non-block body ==
+do doSomething(); while (condition);
+
+[expect]
+do doSomething();
+while (condition);

--- a/tests/specs/statements/doWhileStatement/DoWhileStatement_NextControlFlowPosition_NextLineExceptAfterBrace_Asi.txt
+++ b/tests/specs/statements/doWhileStatement/DoWhileStatement_NextControlFlowPosition_NextLineExceptAfterBrace_Asi.txt
@@ -1,0 +1,10 @@
+~~ semiColons: asi, doWhileStatement.nextControlFlowPosition: nextLineExceptAfterBrace ~~
+== should keep while on same line after brace with ASI ==
+do {
+    doSomething();
+} while (condition);
+
+[expect]
+do {
+    doSomething()
+} while (condition)

--- a/tests/specs/statements/expressionStatement/ExpressionStatement_ForceParentheses_False.txt
+++ b/tests/specs/statements/expressionStatement/ExpressionStatement_ForceParentheses_False.txt
@@ -1,0 +1,62 @@
+~~ expressionStatement.forceParentheses: false ~~
+== should add parentheses around object literal (disambiguation required) ==
+({
+    prop: value
+});
+
+[expect]
+({
+    prop: value,
+});
+
+== should add parentheses around function expression (disambiguation required) ==
+(function test() {
+    return 1;
+});
+
+[expect]
+(function test() {
+    return 1;
+});
+
+== should NOT add parentheses around arrow function ==
+() => 42;
+
+[expect]
+() => 42;
+
+== should NOT add parentheses around simple identifier (not supported) ==
+someVariable;
+
+[expect]
+someVariable;
+
+== should NOT add parentheses around call expression (not supported) ==
+someFunction();
+
+[expect]
+someFunction();
+
+== should NOT add parentheses around member expression (not supported) ==
+obj.prop;
+
+[expect]
+obj.prop;
+
+== should NOT add parentheses around array literal (not supported) ==
+[1, 2, 3];
+
+[expect]
+[1, 2, 3];
+
+== should NOT add parentheses around template literal (not supported) ==
+`hello world`;
+
+[expect]
+`hello world`;
+
+== should NOT add parentheses around binary expression (not supported) ==
+a + b;
+
+[expect]
+a + b;

--- a/tests/specs/statements/expressionStatement/ExpressionStatement_ForceParentheses_True.txt
+++ b/tests/specs/statements/expressionStatement/ExpressionStatement_ForceParentheses_True.txt
@@ -1,0 +1,62 @@
+~~ expressionStatement.forceParentheses: true ~~
+== should add parentheses around object literal ==
+({
+    prop: value
+});
+
+[expect]
+({
+    prop: value,
+});
+
+== should add parentheses around function expression ==
+(function test() {
+    return 1;
+});
+
+[expect]
+(function test() {
+    return 1;
+});
+
+== should add parentheses around arrow function ==
+() => 42;
+
+[expect]
+(() => 42);
+
+== should NOT add parentheses around simple identifier (not supported) ==
+someVariable;
+
+[expect]
+someVariable;
+
+== should NOT add parentheses around call expression (not supported) ==
+someFunction();
+
+[expect]
+someFunction();
+
+== should NOT add parentheses around member expression (not supported) ==
+obj.prop;
+
+[expect]
+obj.prop;
+
+== should NOT add parentheses around array literal (not supported) ==
+[1, 2, 3];
+
+[expect]
+[1, 2, 3];
+
+== should NOT add parentheses around template literal (not supported) ==
+`hello world`;
+
+[expect]
+`hello world`;
+
+== should NOT add parentheses around binary expression (not supported) ==
+a + b;
+
+[expect]
+a + b;

--- a/tests/specs/statements/ifStatement/IfStatement_DanglingElse_Core.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_DanglingElse_Core.txt
@@ -1,0 +1,163 @@
+~~ ifStatement.useBraces: whenNeeded ~~
+== should not add braces when no else clause ==
+if (condition1)
+  if (condition2) doSomething();
+
+[expect]
+if (condition1)
+    if (condition2) doSomething();
+
+== should not add braces when inner if has else ==
+if (condition1)
+  if (condition2) doSomething();
+  else doOtherThing();
+else
+  doThirdThing();
+
+[expect]
+if (condition1)
+    if (condition2) doSomething();
+    else doOtherThing();
+else
+    doThirdThing();
+
+== should add braces for declaration in then branch ==
+if (condition1) {
+  const x = 42;
+}
+else
+  doOtherThing();
+
+[expect]
+if (condition1) {
+    const x = 42;
+} else
+    doOtherThing();
+
+== should keep braces for function declaration in then branch ==
+if (condition1) {
+  function foo() {}
+}
+else
+  doOtherThing();
+
+[expect]
+if (condition1) {
+    function foo() {}
+} else
+    doOtherThing();
+
+== should add braces to resolve dangling else ambiguity ==
+if (condition1) {
+  if (condition2) doSomething();
+}
+else
+  doOtherThing();
+
+[expect]
+if (condition1) {
+    if (condition2) doSomething();
+} else
+    doOtherThing();
+
+== should remove unnecessary braces from else clause ==
+if (condition1) {
+  if (condition2) doSomething();
+} else {
+  doOtherThing();
+}
+
+[expect]
+if (condition1) {
+    if (condition2) doSomething();
+} else
+    doOtherThing();
+
+== should handle nested if statements without dangling else ==
+if (condition1) {
+  if (condition2) {
+    if (condition3) doSomething();
+  }
+}
+
+[expect]
+if (condition1)
+    if (condition2)
+        if (condition3) doSomething();
+
+== should preserve braces when needed for multiple statements ==
+if (condition1) {
+  if (condition2) doSomething();
+  console.log("after");
+} else
+  doOtherThing();
+
+[expect]
+if (condition1) {
+    if (condition2) doSomething();
+    console.log("after");
+} else
+    doOtherThing();
+
+== should add braces for async/await patterns ==
+if (condition1) {
+  await doSomething();
+}
+else
+  doOtherThing();
+
+[expect]
+if (condition1)
+    await doSomething();
+else
+    doOtherThing();
+
+== should handle async function expressions in if blocks ==
+if (condition1) {
+  const result = async () => await fetch("/api");
+} else
+  doOtherThing();
+
+[expect]
+if (condition1) {
+    const result = async () => await fetch("/api");
+} else
+    doOtherThing();
+
+== should add braces for TypeScript type assertions ==
+if (condition1) {
+  const value = data as MyType;
+} else
+  doOtherThing();
+
+[expect]
+if (condition1) {
+    const value = data as MyType;
+} else
+    doOtherThing();
+
+== should handle TypeScript interface declarations ==
+if (condition1) {
+  interface LocalInterface { prop: string; }
+} else
+  doOtherThing();
+
+[expect]
+if (condition1) {
+    interface LocalInterface {
+        prop: string;
+    }
+} else
+    doOtherThing();
+
+== should handle declarations ==
+if (condition1) {
+  const x = 1;
+} else
+  doOtherThing();
+
+[expect]
+if (condition1) {
+    const x = 1;
+} else
+    doOtherThing();

--- a/tests/specs/statements/ifStatement/IfStatement_ElsePositioningAfterBraceRemoval.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_ElsePositioningAfterBraceRemoval.txt
@@ -1,0 +1,76 @@
+~~ ifStatement.useBraces: preferNone, ifStatement.nextControlFlowPosition: maintain ~~
+== should keep else on new line when braces are removed and else was after closing brace ==
+if (true) {
+    a;
+}
+else {
+    b;
+}
+
+[expect]
+if (true)
+    a;
+else
+    b;
+
+== should keep else if on new line when braces are removed and else if was after closing brace ==
+if (true) {
+    a;
+}
+else if (false) {
+    b;
+}
+
+[expect]
+if (true)
+    a;
+else if (false)
+    b;
+
+== should keep else on new line in nested if statements when braces are removed ==
+if (outer) {
+    if (inner) {
+        a;
+    }
+    else {
+        b;
+    }
+}
+
+[expect]
+if (outer) {
+    if (inner)
+        a;
+    else
+        b;
+}
+
+== should handle multiple else if clauses with proper positioning ==
+if (a) {
+    first();
+}
+else if (b) {
+    second();
+}
+else if (c) {
+    third();
+}
+else {
+    fourth();
+}
+
+[expect]
+if (a)
+    first();
+else if (b)
+    second();
+else if (c)
+    third();
+else
+    fourth();
+
+== should handle inline else positioning when braces are removed ==
+if (true) { a; } else { b; }
+
+[expect]
+if (true) a; else b;

--- a/tests/specs/statements/ifStatement/IfStatement_ElsePositioning_Comprehensive.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_ElsePositioning_Comprehensive.txt
@@ -1,0 +1,106 @@
+~~ ifStatement.useBraces: whenNeeded, ifStatement.nextControlFlowPosition: maintain ~~
+== should maintain spacing after brace removal for simple else ==
+if (condition) {
+  doSomething();
+} else {
+  doOtherThing();
+}
+
+[expect]
+if (condition)
+    doSomething();
+else
+    doOtherThing();
+
+== should maintain spacing after brace removal for simple else ==
+if (condition) doSomething();
+else doOtherThing();
+
+[expect]
+if (condition) doSomething();
+else doOtherThing();
+
+== should handle else-if positioning after brace removal ==
+if (condition1) {
+  doSomething();
+} else if (condition2) {
+  doOtherThing();
+} else {
+  doThirdThing();
+}
+
+[expect]
+if (condition1)
+    doSomething();
+else if (condition2)
+    doOtherThing();
+else
+    doThirdThing();
+
+== should handle mixed brace scenarios ==
+if (condition1) {
+  const value = 42;
+} else if (condition2) {
+  doOtherThing();
+} else {
+  doThirdThing();
+}
+
+[expect]
+if (condition1) {
+    const value = 42;
+} else if (condition2)
+    doOtherThing();
+else
+    doThirdThing();
+
+== should handle dangling else with proper positioning ==
+if (condition1) {
+  if (condition2) doSomething();
+} else {
+  doOtherThing();
+}
+
+[expect]
+if (condition1) {
+    if (condition2) doSomething();
+} else
+    doOtherThing();
+
+== should handle comments before else ==
+if (condition) {
+  doSomething();
+}
+// comment before else
+else {
+  doOtherThing();
+}
+
+[expect]
+if (condition)
+    doSomething();
+// comment before else
+else
+    doOtherThing();
+
+== should handle multiline comments before else ==
+if (condition) {
+  doSomething();
+}
+/*
+ * multiline comment
+ * before else
+ */
+else {
+  doOtherThing();
+}
+
+[expect]
+if (condition)
+    doSomething();
+/*
+ * multiline comment
+ * before else
+ */
+else
+    doOtherThing();

--- a/tests/specs/statements/ifStatement/IfStatement_ElsePositioning_NextLineExceptAfterBrace.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_ElsePositioning_NextLineExceptAfterBrace.txt
@@ -1,0 +1,124 @@
+~~ ifStatement.nextControlFlowPosition: nextLineExceptAfterBrace, ifStatement.useBraces: whenNotSingleLine, ifStatement.singleBodyPosition: maintain ~~
+== should force else to new line for simple statements ==
+if (condition) doSomething(); else doOther();
+
+[expect]
+if (condition) doSomething();
+else doOther();
+
+== should force else to new line for non-braced then clause ==
+if (condition) 
+  doSomething(); 
+else 
+  doOther();
+
+[expect]
+if (condition) {
+    doSomething();
+} else {
+    doOther();
+}
+
+== should keep else on same line after closing brace ==
+if (condition) {
+  doSomething();
+} else {
+  doOther();
+}
+
+[expect]
+if (condition) {
+    doSomething();
+} else {
+    doOther();
+}
+
+== should keep else on same line after closing brace - single line ==
+if (condition) { doSomething(); } else { doOther(); }
+
+[expect]
+if (condition) doSomething();
+else doOther();
+
+== should handle mixed braced and non-braced ==
+if (condition) {
+  doSomething();
+} else doOther();
+
+[expect]
+if (condition) {
+    doSomething();
+} else doOther();
+
+== should handle mixed non-braced and braced ==
+if (condition) doSomething(); else {
+  doOther();
+}
+
+[expect]
+if (condition) doSomething();
+else {
+    doOther();
+}
+
+== should handle nested if-else statements ==
+if (condition1) doFirst(); else if (condition2) doSecond(); else doThird();
+
+[expect]
+if (condition1) doFirst();
+else if (condition2) doSecond();
+else doThird();
+
+== should handle nested if-else with braces ==
+if (condition1) {
+  doFirst();
+} else if (condition2) {
+  doSecond();
+} else {
+  doThird();
+}
+
+[expect]
+if (condition1) {
+    doFirst();
+} else if (condition2) {
+    doSecond();
+} else {
+    doThird();
+}
+
+== should handle complex mixed scenarios ==
+if (condition1) {
+  doFirst();
+} else if (condition2) doSecond(); else {
+  doThird();
+}
+
+[expect]
+if (condition1) {
+    doFirst();
+} else if (condition2) doSecond();
+else {
+    doThird();
+}
+
+== should work with function declarations ==
+if (condition) function test1() { return 1; } else function test2() { return 2; }
+
+[expect]
+if (condition) {
+    function test1() {
+        return 1;
+    }
+} else {
+    function test2() {
+        return 2;
+    }
+}
+
+== should work with arrow functions ==
+if (condition) () => 1; else () => 2;
+
+[expect]
+if (condition) (() => 1);
+else (() => 2);

--- a/tests/specs/statements/ifStatement/IfStatement_ElsePositioning_NextLineExceptAfterBrace_WhenFormattedMultiLine_NewLine.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_ElsePositioning_NextLineExceptAfterBrace_WhenFormattedMultiLine_NewLine.txt
@@ -1,0 +1,72 @@
+~~ ifStatement.nextControlFlowPosition: nextLineExceptAfterBrace, ifStatement.useBraces: whenFormattedMultiLine, ifStatement.singleBodyPosition: nextLine ~~
+== should force else to new line with single statements when not formatted multiline ==
+if (condition) doSomething(); else doOther();
+
+[expect]
+if (condition)
+    doSomething();
+else
+    doOther();
+
+== should add braces when statements are formatted multiline ==
+if (condition) console.log("this is a very long statement that will be formatted on multiple lines"); else console.log("another very long statement");
+
+[expect]
+if (condition)
+    console.log("this is a very long statement that will be formatted on multiple lines");
+else
+    console.log("another very long statement");
+
+== should handle await expressions with multiline formatting ==
+if (condition) await veryLongFunctionNameThatMakesThisLineVeryLong(); else await anotherVeryLongFunction();
+
+[expect]
+if (condition)
+    await veryLongFunctionNameThatMakesThisLineVeryLong();
+else
+    await anotherVeryLongFunction();
+
+== should keep braces when already multiline ==
+if (condition) {
+    const x = 1;
+    doSomething();
+} else {
+    const y = 2;
+    doOther();
+}
+
+[expect]
+if (condition) {
+    const x = 1;
+    doSomething();
+} else {
+    const y = 2;
+    doOther();
+}
+
+== should handle mixed scenarios with some multiline and some single line ==
+if (condition) veryLongFunctionNameThatWillCauseWrapping(); else if (condition2) doShort(); else {
+    multipleStatements();
+    here();
+}
+
+[expect]
+if (condition)
+    veryLongFunctionNameThatWillCauseWrapping();
+else if (condition2)
+    doShort();
+else {
+    multipleStatements();
+    here();
+}
+
+== should work with function expressions that become multiline ==
+if (condition) function veryLongFunctionName() { return someVeryLongExpressionThatCausesWrapping; } else shortFunc();
+
+[expect]
+if (condition) {
+    function veryLongFunctionName() {
+        return someVeryLongExpressionThatCausesWrapping;
+    }
+} else
+    shortFunc();

--- a/tests/specs/statements/ifStatement/IfStatement_ElsePositioning_NextLineExceptAfterBrace_WhenNeeded_NewLine.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_ElsePositioning_NextLineExceptAfterBrace_WhenNeeded_NewLine.txt
@@ -1,0 +1,90 @@
+~~ ifStatement.nextControlFlowPosition: nextLineExceptAfterBrace, ifStatement.useBraces: whenNeeded, ifStatement.singleBodyPosition: nextLine ~~
+== should force else to new line with single statements ==
+if (condition) doSomething(); else doOther();
+
+[expect]
+if (condition)
+    doSomething();
+else
+    doOther();
+
+== should handle await expressions requiring braces ==
+if (condition) await someAsyncFunction(); else await anotherAsyncFunction();
+
+[expect]
+if (condition)
+    await someAsyncFunction();
+else
+    await anotherAsyncFunction();
+
+== should handle mixed single and multiple statements ==
+if (condition) {
+    const x = 1;
+    doSomething();
+} else doOther();
+
+[expect]
+if (condition) {
+    const x = 1;
+    doSomething();
+} else
+    doOther();
+
+== should handle mixed multiple and single statements ==
+if (condition) doSomething(); else {
+    const y = 2;
+    doOther();
+}
+
+[expect]
+if (condition)
+    doSomething();
+else {
+    const y = 2;
+    doOther();
+}
+
+== should handle nested if with dangling else protection ==
+if (condition1) if (condition2) doFirst(); else doSecond();
+
+[expect]
+if (condition1)
+    if (condition2)
+        doFirst();
+    else
+        doSecond();
+
+== should handle nested if with dangling else protection ==
+if (condition1) if (condition2) doFirst(); else doSecond(); else doThird();
+
+[expect]
+if (condition1)
+    if (condition2)
+        doFirst();
+    else
+        doSecond();
+else
+    doThird();
+
+== should handle complex nested scenarios ==
+if (condition1) {
+    const x = 1;
+    if (nested) doNested(); else doOther();
+} else if (condition2) doSecond(); else {
+    const y = 2;
+    doFinal();
+}
+
+[expect]
+if (condition1) {
+    const x = 1;
+    if (nested)
+        doNested();
+    else
+        doOther();
+} else if (condition2)
+    doSecond();
+else {
+    const y = 2;
+    doFinal();
+}

--- a/tests/specs/statements/ifStatement/IfStatement_ElsePositioning_WithForceNewLine.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_ElsePositioning_WithForceNewLine.txt
@@ -1,0 +1,22 @@
+~~ ifStatement.nextControlFlowPosition: nextLineExceptAfterBrace, ifStatement.useBraces: whenNotSingleLine, ifStatement.singleBodyPosition: nextLine ~~
+== should combine NextLineExceptAfterBrace with nextLine ==
+if (condition) doSomething(); else doOther();
+
+[expect]
+if (condition) {
+    doSomething();
+} else {
+    doOther();
+}
+
+== should handle mixed braced and non-braced with both settings ==
+if (condition) {
+  doSomething();
+} else doOther();
+
+[expect]
+if (condition) {
+    doSomething();
+} else {
+    doOther();
+}

--- a/tests/specs/statements/ifStatement/IfStatement_ElsePositioning_WithWhenFormattedMultiLine.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_ElsePositioning_WithWhenFormattedMultiLine.txt
@@ -1,0 +1,63 @@
+~~ ifStatement.nextControlFlowPosition: nextLineExceptAfterBrace, ifStatement.useBraces: whenFormattedMultiLine, ifStatement.singleBodyPosition: maintain ~~
+== should force else to new line with single statements when not formatted multiline ==
+if (condition) doSomething(); else doOther();
+
+[expect]
+if (condition) doSomething();
+else doOther();
+
+== should add braces when statements are formatted multiline ==
+if (condition) console.log("this is a very long statement that will be formatted on multiple lines"); else console.log("another very long statement");
+
+[expect]
+if (condition) console.log("this is a very long statement that will be formatted on multiple lines");
+else console.log("another very long statement");
+
+== should handle await expressions with multiline formatting ==
+if (condition) await veryLongFunctionNameThatMakesThisLineVeryLong(); else await anotherVeryLongFunction();
+
+[expect]
+if (condition) await veryLongFunctionNameThatMakesThisLineVeryLong();
+else await anotherVeryLongFunction();
+
+== should keep braces when already multiline ==
+if (condition) {
+    const x = 1;
+    doSomething();
+} else {
+    const y = 2;
+    doOther();
+}
+
+[expect]
+if (condition) {
+    const x = 1;
+    doSomething();
+} else {
+    const y = 2;
+    doOther();
+}
+
+== should handle mixed scenarios with some multiline and some single line ==
+if (condition) veryLongFunctionNameThatWillCauseWrapping(); else if (condition2) doShort(); else {
+    multipleStatements();
+    here();
+}
+
+[expect]
+if (condition) veryLongFunctionNameThatWillCauseWrapping();
+else if (condition2) doShort();
+else {
+    multipleStatements();
+    here();
+}
+
+== should work with function expressions that become multiline ==
+if (condition) function veryLongFunctionName() { return someVeryLongExpressionThatCausesWrapping; } else shortFunc();
+
+[expect]
+if (condition) {
+    function veryLongFunctionName() {
+        return someVeryLongExpressionThatCausesWrapping;
+    }
+} else shortFunc();

--- a/tests/specs/statements/ifStatement/IfStatement_ElsePositioning_WithWhenNeeded.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_ElsePositioning_WithWhenNeeded.txt
@@ -1,0 +1,90 @@
+~~ ifStatement.nextControlFlowPosition: nextLineExceptAfterBrace, ifStatement.useBraces: whenNeeded, ifStatement.singleBodyPosition: maintain ~~
+== should force else to new line with single statements ==
+if (condition) doSomething(); else doOther();
+
+[expect]
+if (condition) doSomething();
+else doOther();
+
+== should keep else on same line after closing brace with whenNeeded ==
+if (condition) {
+  const x = 1;
+  doSomething();
+} else {
+  const y = 2;
+  doOther();
+}
+
+[expect]
+if (condition) {
+    const x = 1;
+    doSomething();
+} else {
+    const y = 2;
+    doOther();
+}
+
+== should handle await expressions requiring braces ==
+if (condition) await doAsync(); else await doOtherAsync();
+
+[expect]
+if (condition) await doAsync();
+else await doOtherAsync();
+
+== should handle mixed single and multiple statements ==
+if (condition) doSomething(); else {
+  const x = 1;
+  doOther();
+}
+
+[expect]
+if (condition) doSomething();
+else {
+    const x = 1;
+    doOther();
+}
+
+== should handle mixed multiple and single statements ==
+if (condition) {
+  const x = 1;
+  doSomething();
+} else doOther();
+
+[expect]
+if (condition) {
+    const x = 1;
+    doSomething();
+} else doOther();
+
+== should handle nested if with dangling else protection ==
+if (condition1) if (condition2) doSomething(); else doOther();
+
+[expect]
+if (condition1)
+    if (condition2) doSomething();
+    else doOther();
+
+== should handle nested if with dangling else protection ==
+if (condition1) { if (condition2) doSomething(); } else doOther();
+
+[expect]
+if (condition1) { if (condition2) doSomething(); } else doOther();
+
+== should handle complex nested scenarios ==
+if (condition1) {
+  const x = 1;
+  if (condition2) doNested();
+} else if (condition3) await doAsync(); else {
+  const y = 2;
+  doFinal();
+}
+
+[expect]
+if (condition1) {
+    const x = 1;
+    if (condition2) doNested();
+} else if (condition3) await doAsync();
+else {
+    const y = 2;
+    doFinal();
+}

--- a/tests/specs/statements/ifStatement/IfStatement_EmptyStatements_Core.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_EmptyStatements_Core.txt
@@ -1,0 +1,120 @@
+~~ ifStatement.useBraces: whenNeeded ~~
+== should keep braces for truly empty block ==
+if (condition) {}
+
+[expect]
+if (condition) {}
+
+== should keep braces for block with only empty statements ==
+if (condition) {
+  ;
+}
+
+[expect]
+if (condition) {
+}
+
+== should remove braces when empty statement plus single expression ==
+if (condition) {
+  ;
+  doSomething();
+}
+
+[expect]
+if (condition)
+    doSomething();
+
+== should keep braces when empty statement plus declaration ==
+if (condition) {
+  ;
+  const value = 42;
+}
+
+[expect]
+if (condition) {
+    const value = 42;
+}
+
+== should remove braces for expression plus empty statement ==
+if (condition) {
+  doSomething();
+  ;
+}
+
+[expect]
+if (condition)
+    doSomething();
+
+== should keep braces for declaration plus empty statement ==
+if (condition) {
+  const value = 42;
+  ;
+}
+
+[expect]
+if (condition) {
+    const value = 42;
+}
+
+== should handle multiple empty statements ==
+if (condition) {
+  ;
+  ;
+  ;
+}
+
+[expect]
+if (condition) {
+}
+
+== should handle mixed empty statements and expressions ==
+if (condition) {
+  ;
+  doSomething();
+  ;
+  doOtherThing();
+}
+
+[expect]
+if (condition) {
+    doSomething();
+
+    doOtherThing();
+}
+
+== should handle empty statements with await expressions ==
+if (condition) {
+  ;
+  await doSomething();
+}
+
+[expect]
+if (condition)
+    await doSomething();
+
+== should handle empty statements with function declarations ==
+if (condition) {
+  ;
+  function myFunc() {}
+}
+
+[expect]
+if (condition) {
+    function myFunc() {}
+}
+
+== should handle complex mixed scenarios ==
+if (condition) {
+  ;
+  const x = 42;
+  ;
+  doSomething();
+  ;
+}
+
+[expect]
+if (condition) {
+    const x = 42;
+
+    doSomething();
+}

--- a/tests/specs/statements/ifStatement/IfStatement_PreferNone_SingleLine_Maintain.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_PreferNone_SingleLine_Maintain.txt
@@ -1,0 +1,70 @@
+~~ ifStatement.useBraces: preferNone, ifStatement.nextControlFlowPosition: maintain, preferSingleLine: true ~~
+== should format if-else with preferNone, preferSingleLine, and maintain ==
+if (true)
+  a;
+else if (true)
+  b;
+
+[expect]
+if (true)
+    a;
+else if (true)
+    b;
+
+== should handle nested conditions ==
+if (condition1)
+  statement1();
+else if (condition2)
+  statement2();
+else
+  statement3();
+
+[expect]
+if (condition1)
+    statement1();
+else if (condition2)
+    statement2();
+else
+    statement3();
+
+== should keep braces when multiple statements but remove for single ==
+if (true) {
+  a;
+  b;
+} else if (true) {
+  c;
+}
+
+[expect]
+if (true) {
+    a;
+    b;
+} else if (true) {
+    c;
+}
+
+== should keep braces for declarations ==
+if (true) {
+  const x = 1;
+} else if (true) {
+  let y = 2;
+}
+
+[expect]
+if (true) {
+    const x = 1;
+} else if (true) {
+    let y = 2;
+}
+
+== should maintain control flow position ==
+if (condition1)
+  statement1();
+else if (condition2)
+  statement2();
+
+[expect]
+if (condition1)
+    statement1();
+else if (condition2)
+    statement2();

--- a/tests/specs/statements/ifStatement/IfStatement_SimpleStatementPositioning_Core.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_SimpleStatementPositioning_Core.txt
@@ -1,0 +1,87 @@
+~~ ifStatement.singleBodyPosition: nextLine, ifStatement.useBraces: maintain ~~
+== should force non-braced statements to new line with nextLine ==
+if (condition) statement();
+
+[expect]
+if (condition)
+    statement();
+
+== should force else statements to new line with nextLine ==
+if (condition) stmt1();
+else stmt2();
+
+[expect]
+if (condition)
+    stmt1();
+else
+    stmt2();
+
+== should not affect braced blocks with nextLine (BracePosition controls) ==
+if (condition) {
+    statement();
+}
+
+[expect]
+if (condition) {
+    statement();
+}
+
+== should not affect braced else blocks with nextLine ==
+if (condition) {
+    stmt1();
+} else {
+    stmt2();
+}
+
+[expect]
+if (condition) {
+    stmt1();
+} else {
+    stmt2();
+}
+
+== should handle mixed braced and non-braced with nextLine ==
+if (condition) {
+    stmt1();
+} else stmt2();
+
+[expect]
+if (condition) {
+    stmt1();
+} else
+    stmt2();
+
+== should handle nested if statements with nextLine ==
+if (condition1) if (condition2) statement();
+
+[expect]
+if (condition1) {
+    if (condition2)
+        statement();
+}
+
+== should handle complex expressions with nextLine ==
+if (condition) console.log("message");
+
+[expect]
+if (condition)
+    console.log("message");
+
+== should handle return statements with nextLine ==
+if (condition) return value;
+
+[expect]
+if (condition)
+    return value;
+
+== should handle multiple non-braced statements (via block) ==
+if (condition) {
+    stmt1();
+    stmt2();
+}
+
+[expect]
+if (condition) {
+    stmt1();
+    stmt2();
+}

--- a/tests/specs/statements/ifStatement/IfStatement_SimpleStatementPositioning_WhenNeeded.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_SimpleStatementPositioning_WhenNeeded.txt
@@ -1,0 +1,71 @@
+~~ ifStatement.singleBodyPosition: nextLine, ifStatement.useBraces: whenNeeded ~~
+== should handle empty statements correctly ==
+if (condition) ;
+
+[expect]
+if (condition);
+
+== should force new line with whenNeeded - simple expression ==
+if (condition) doSomething();
+
+[expect]
+if (condition)
+    doSomething();
+
+== should force new line with whenNeeded - else clause ==
+if (condition) doFirst();
+else doSecond();
+
+[expect]
+if (condition)
+    doFirst();
+else
+    doSecond();
+
+== should add braces when syntactically needed with nextLine ==
+if (condition) { const x = 1; }
+
+[expect]
+if (condition) {
+    const x = 1;
+}
+
+== should add braces for await expressions with nextLine ==
+if (condition) await doSomething();
+
+[expect]
+if (condition)
+    await doSomething();
+
+== should keep braces for function declarations with nextLine ==
+if (condition) function test() { return 1; }
+
+[expect]
+if (condition) {
+    function test() {
+        return 1;
+    }
+}
+
+== should handle mixed scenarios with whenNeeded ==
+if (condition1) { const x = 1; }
+else if (condition2) doSomething();
+else { await doAsync(); }
+
+[expect]
+if (condition1) {
+    const x = 1;
+} else if (condition2)
+    doSomething();
+else
+    await doAsync();
+
+== should handle dangling else with nextLine - nested if with else ==
+if (condition1) if (condition2) doSomething(); else doOther();
+
+[expect]
+if (condition1)
+    if (condition2)
+        doSomething();
+    else
+        doOther();

--- a/tests/specs/statements/ifStatement/IfStatement_UseBraces_OnlyNeeded.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_UseBraces_OnlyNeeded.txt
@@ -1,0 +1,82 @@
+~~ ifStatement.useBraces: whenNeeded ~~
+== should only add braces when syntactically necessary ==
+if (condition)
+  doSomething();
+
+[expect]
+if (condition)
+    doSomething();
+
+== should add braces for empty block ==
+if (condition) {
+}
+
+[expect]
+if (condition) {
+}
+
+== should add braces for multiple statements ==
+if (condition) {
+  doSomething();
+  doAnotherThing();
+}
+
+[expect]
+if (condition) {
+    doSomething();
+    doAnotherThing();
+}
+
+== should add braces for variable declarations ==
+if (condition) {
+  const value = 42;
+}
+
+[expect]
+if (condition) {
+    const value = 42;
+}
+
+== should add braces for let declarations ==
+if (condition) {
+  let value = 42;
+}
+
+[expect]
+if (condition) {
+    let value = 42;
+}
+
+== should add braces for class declarations ==
+if (condition) {
+  class MyClass {}
+}
+
+[expect]
+if (condition) {
+    class MyClass {}
+}
+
+== should keep braces for function declarations ==
+if (condition) {
+  function myFunc() {}
+}
+
+[expect]
+if (condition) {
+    function myFunc() {}
+}
+
+== should keep braces for single function declaration ==
+if (condition) {
+  function myFunc() {
+    return 42;
+  }
+}
+
+[expect]
+if (condition) {
+    function myFunc() {
+        return 42;
+    }
+}

--- a/tests/specs/statements/ifStatement/IfStatement_UseBraces_WhenFormattedMultiLine.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_UseBraces_WhenFormattedMultiLine.txt
@@ -1,0 +1,88 @@
+~~ lineWidth: 40, ifStatement.useBraces: whenFormattedMultiLine ~~
+== should not add braces for single line statement ==
+if (condition) doSomething();
+
+[expect]
+if (condition) doSomething();
+
+== should add braces when statement would be formatted on multiple lines ==
+if (condition) doSomethingVeryLongThatExceedsTheLineWidth();
+
+[expect]
+if (condition)
+    doSomethingVeryLongThatExceedsTheLineWidth();
+
+== should add braces when condition itself is multi-line ==
+if (someVeryLongConditionThatExceedsWidth)
+  doSomething();
+
+[expect]
+if (someVeryLongConditionThatExceedsWidth)
+    doSomething();
+
+== should handle if-else chain ==
+if (shortCondition) shortStatement();
+else if (anotherVeryLongConditionThatExceedsTheLineWidth) doSomething();
+else doAnotherThing();
+
+[expect]
+if (shortCondition) shortStatement();
+else if (
+    anotherVeryLongConditionThatExceedsTheLineWidth
+) doSomething();
+else doAnotherThing();
+
+== should add braces for already multi-line content ==
+if (condition) {
+  doSomething();
+  doAnotherThing();
+}
+
+[expect]
+if (condition) {
+    doSomething();
+    doAnotherThing();
+}
+
+== should handle empty blocks ==
+if (condition) {
+}
+
+[expect]
+if (condition) {
+}
+
+== should handle declarations that would be multi-line ==
+if (condition) { const veryLongVariableNameThatExceedsWidth = 42; }
+
+[expect]
+if (condition) {
+    const veryLongVariableNameThatExceedsWidth =
+        42;
+}
+
+== should preserve single line when everything fits ==
+if (short) brief();
+else if (also) quick();
+else final();
+
+[expect]
+if (short) brief();
+else if (also) quick();
+else final();
+
+== should preserve single line when everything fits ==
+if (short) {
+  brief();
+} else if (also) {
+  quick();
+} else
+  final();
+
+[expect]
+if (short)
+    brief();
+else if (also)
+    quick();
+else
+    final();

--- a/tests/specs/statements/ifStatement/IfStatement_UseBraces_WhenNeeded.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_UseBraces_WhenNeeded.txt
@@ -1,0 +1,100 @@
+~~ ifStatement.useBraces: whenNeeded ~~
+== should not add braces for single statement ==
+if (condition)
+  doSomething();
+
+[expect]
+if (condition)
+    doSomething();
+
+== should add braces for empty block ==
+if (condition) {
+}
+
+[expect]
+if (condition) {
+}
+
+== should add braces for multiple statements ==
+if (condition) {
+  doSomething();
+  doAnotherThing();
+}
+
+[expect]
+if (condition) {
+    doSomething();
+    doAnotherThing();
+}
+
+== should add braces for declarations ==
+if (condition) {
+  const value = 42;
+}
+
+[expect]
+if (condition) {
+    const value = 42;
+}
+
+== should handle if-else chain independently ==
+if (condition1)
+  statement1();
+else if (condition2) {
+  const value = 42;
+}
+else
+  statement3();
+
+[expect]
+if (condition1)
+    statement1();
+else if (condition2) {
+    const value = 42;
+} else
+    statement3();
+
+== should remove unnecessary braces from single expressions ==
+if (condition) {
+  doSomething();
+}
+
+[expect]
+if (condition)
+    doSomething();
+
+== should handle nested if statements ==
+if (condition1)
+  if (condition2)
+    doSomething();
+
+[expect]
+if (condition1)
+    if (condition2)
+        doSomething();
+
+== should keep braces for function declarations ==
+if (condition) {
+  function innerFunc() {
+    return 42;
+  }
+}
+
+[expect]
+if (condition) {
+    function innerFunc() {
+        return 42;
+    }
+}
+
+== should add braces when syntactically required ==
+if (condition) {
+  if (true) f()
+} else
+  g();
+
+[expect]
+if (condition) {
+    if (true) f();
+} else
+    g();

--- a/tests/specs/statements/tryStatement/TryStatement_NextControlFlowPosition_NextLineExceptAfterBrace.txt
+++ b/tests/specs/statements/tryStatement/TryStatement_NextControlFlowPosition_NextLineExceptAfterBrace.txt
@@ -1,0 +1,14 @@
+~~ tryStatement.nextControlFlowPosition: nextLineExceptAfterBrace ~~
+== should keep catch on same line after brace ==
+try {
+    doSomething();
+} catch (err) {
+    handleError();
+}
+
+[expect]
+try {
+    doSomething();
+} catch (err) {
+    handleError();
+}

--- a/tests/specs/statements/whileStatement/WhileStatement_UseBraces_WhenNeeded.txt
+++ b/tests/specs/statements/whileStatement/WhileStatement_UseBraces_WhenNeeded.txt
@@ -1,0 +1,10 @@
+~~ whileStatement.useBraces: whenNeeded ~~
+== should keep braces for declaration bodies ==
+while (true) {
+    const value = 1;
+}
+
+[expect]
+while (true) {
+    const value = 1;
+}


### PR DESCRIPTION
This PR adds new configuration options for more granular control over brace usage and ternary expression indentation.

## New Configuration Options

**useBraces modes:**
- `whenFormattedMultiLine` - Uses braces when the formatted code spans multiple lines, removing them for single-line statements
- `onlyNeeded` - Uses braces only when needed for clarity or safety (e.g., dangling else, strict mode declarations), avoiding them when the statement is simple and unambiguous

**Ternary indentation:**
- `ternaryIndentStyle: "structural"` - Uses structural indentation for conditional expressions to avoid deep nesting
- `ternaryIndentStyle: "align"` - Aligns the ? and : operators under the condition (default, maintains current behavior)

**Expression statement parentheses:**
- `expressionStatement.forceParentheses` - Controls whether to force parentheses around expression statements (default: true, maintains current behavior)

**nextControlFlowPosition enhancement:**
- `nextLineExceptAfterBrace` - New option that forces the next control flow to be on the next line, except when preceded by a brace (useful for consistent else/catch/finally positioning)

## Test Coverage

Added 24 new test specification files covering:
- Different useBraces modes with various statement types
- Dangling else scenarios
- Control flow positioning with try-catch-finally and do-while
- Ternary indentation styles
- Expression statement parentheses