### PR TITLE
feat: add whenNeeded and whenFormattedMultiLine brace modes

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -151,6 +151,12 @@
       }, {
         "const": "preferNone",
         "description": "Forces no braces when the header is one line and body is one line. Otherwise forces braces."
+      }, {
+        "const": "whenNeeded",
+        "description": "Uses braces when needed for clarity or safety, avoiding them when the statement is simple and unambiguous."
+      }, {
+        "const": "whenFormattedMultiLine",
+        "description": "Uses braces when the formatted code spans multiple lines, removing them for single-line statements."
       }]
     },
     "bracePosition": {

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -93,6 +93,7 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
     quote_props,
     semi_colons,
     file_indent_level: get_value(&mut config, "fileIndentLevel", 0, &mut diagnostics),
+    prefer_single_line,
     /* situational */
     arrow_function_use_parentheses: get_value(&mut config, "arrowFunction.useParentheses", UseParentheses::Maintain, &mut diagnostics),
     binary_expression_line_per_expression: get_value(&mut config, "binaryExpression.linePerExpression", false, &mut diagnostics),

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -163,6 +163,10 @@ pub enum UseBraces {
   Always,
   /// Forces no braces when the header is one line and body is one line. Otherwise forces braces.
   PreferNone,
+  /// Only uses braces when syntactically required (empty blocks, declarations, multiple statements).
+  WhenNeeded,
+  /// Uses braces when the formatted body spans multiple lines.
+  WhenFormattedMultiLine,
 }
 
 generate_str_to_from![
@@ -170,7 +174,9 @@ generate_str_to_from![
   [Maintain, "maintain"],
   [WhenNotSingleLine, "whenNotSingleLine"],
   [Always, "always"],
-  [PreferNone, "preferNone"]
+  [PreferNone, "preferNone"],
+  [WhenNeeded, "whenNeeded"],
+  [WhenFormattedMultiLine, "whenFormattedMultiLine"]
 ];
 
 /// Whether to use parentheses around a single parameter in an arrow function.
@@ -318,6 +324,7 @@ pub struct Configuration {
   pub quote_props: QuoteProps,
   pub semi_colons: SemiColons,
   pub file_indent_level: u32,
+  pub prefer_single_line: bool,
   /* situational */
   #[serde(rename = "arrowFunction.useParentheses")]
   pub arrow_function_use_parentheses: UseParentheses,

--- a/tests/specs/statements/ifStatement/IfStatement_DanglingElse_Core.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_DanglingElse_Core.txt
@@ -1,0 +1,163 @@
+~~ ifStatement.useBraces: whenNeeded ~~
+== should not add braces when no else clause ==
+if (condition1)
+  if (condition2) doSomething();
+
+[expect]
+if (condition1)
+    if (condition2) doSomething();
+
+== should not add braces when inner if has else ==
+if (condition1)
+  if (condition2) doSomething();
+  else doOtherThing();
+else
+  doThirdThing();
+
+[expect]
+if (condition1)
+    if (condition2) doSomething();
+    else doOtherThing();
+else
+    doThirdThing();
+
+== should keep braces for declaration in then branch ==
+if (condition1) {
+  const x = 42;
+}
+else
+  doOtherThing();
+
+[expect]
+if (condition1) {
+    const x = 42;
+} else
+    doOtherThing();
+
+== should keep braces for function declaration in then branch ==
+if (condition1) {
+  function foo() {}
+}
+else
+  doOtherThing();
+
+[expect]
+if (condition1) {
+    function foo() {}
+} else
+    doOtherThing();
+
+== should keep braces to resolve dangling else ambiguity ==
+if (condition1) {
+  if (condition2) doSomething();
+}
+else
+  doOtherThing();
+
+[expect]
+if (condition1) {
+    if (condition2) doSomething();
+} else
+    doOtherThing();
+
+== should remove unnecessary braces from else clause ==
+if (condition1) {
+  if (condition2) doSomething();
+} else {
+  doOtherThing();
+}
+
+[expect]
+if (condition1) {
+    if (condition2) doSomething();
+} else
+    doOtherThing();
+
+== should handle nested if statements without dangling else ==
+if (condition1) {
+  if (condition2) {
+    if (condition3) doSomething();
+  }
+}
+
+[expect]
+if (condition1)
+    if (condition2)
+        if (condition3) doSomething();
+
+== should preserve braces when needed for multiple statements ==
+if (condition1) {
+  if (condition2) doSomething();
+  console.log("after");
+} else
+  doOtherThing();
+
+[expect]
+if (condition1) {
+    if (condition2) doSomething();
+    console.log("after");
+} else
+    doOtherThing();
+
+== should remove braces for async/await patterns ==
+if (condition1) {
+  await doSomething();
+}
+else
+  doOtherThing();
+
+[expect]
+if (condition1)
+    await doSomething();
+else
+    doOtherThing();
+
+== should handle async function expressions in if blocks ==
+if (condition1) {
+  const result = async () => await fetch("/api");
+} else
+  doOtherThing();
+
+[expect]
+if (condition1) {
+    const result = async () => await fetch("/api");
+} else
+    doOtherThing();
+
+== should keep braces for TypeScript type assertions ==
+if (condition1) {
+  const value = data as MyType;
+} else
+  doOtherThing();
+
+[expect]
+if (condition1) {
+    const value = data as MyType;
+} else
+    doOtherThing();
+
+== should handle TypeScript interface declarations ==
+if (condition1) {
+  interface LocalInterface { prop: string; }
+} else
+  doOtherThing();
+
+[expect]
+if (condition1) {
+    interface LocalInterface {
+        prop: string;
+    }
+} else
+    doOtherThing();
+
+== should handle declarations ==
+if (condition1) {
+  const x = 1;
+} else
+  doOtherThing();
+
+[expect]
+if (condition1) {
+    const x = 1;
+} else
+    doOtherThing();

--- a/tests/specs/statements/ifStatement/IfStatement_EmptyStatements_Core.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_EmptyStatements_Core.txt
@@ -1,0 +1,120 @@
+~~ ifStatement.useBraces: whenNeeded ~~
+== should keep braces for truly empty block ==
+if (condition) {}
+
+[expect]
+if (condition) {}
+
+== should keep braces for block with only empty statements ==
+if (condition) {
+  ;
+}
+
+[expect]
+if (condition) {
+}
+
+== should remove braces when empty statement plus single expression ==
+if (condition) {
+  ;
+  doSomething();
+}
+
+[expect]
+if (condition)
+    doSomething();
+
+== should keep braces when empty statement plus declaration ==
+if (condition) {
+  ;
+  const value = 42;
+}
+
+[expect]
+if (condition) {
+    const value = 42;
+}
+
+== should remove braces for expression plus empty statement ==
+if (condition) {
+  doSomething();
+  ;
+}
+
+[expect]
+if (condition)
+    doSomething();
+
+== should keep braces for declaration plus empty statement ==
+if (condition) {
+  const value = 42;
+  ;
+}
+
+[expect]
+if (condition) {
+    const value = 42;
+}
+
+== should handle multiple empty statements ==
+if (condition) {
+  ;
+  ;
+  ;
+}
+
+[expect]
+if (condition) {
+}
+
+== should handle mixed empty statements and expressions ==
+if (condition) {
+  ;
+  doSomething();
+  ;
+  doOtherThing();
+}
+
+[expect]
+if (condition) {
+    doSomething();
+
+    doOtherThing();
+}
+
+== should handle empty statements with await expressions ==
+if (condition) {
+  ;
+  await doSomething();
+}
+
+[expect]
+if (condition)
+    await doSomething();
+
+== should handle empty statements with function declarations ==
+if (condition) {
+  ;
+  function myFunc() {}
+}
+
+[expect]
+if (condition) {
+    function myFunc() {}
+}
+
+== should handle complex mixed scenarios ==
+if (condition) {
+  ;
+  const x = 42;
+  ;
+  doSomething();
+  ;
+}
+
+[expect]
+if (condition) {
+    const x = 42;
+
+    doSomething();
+}

--- a/tests/specs/statements/ifStatement/IfStatement_PreferNone_SingleLine_Maintain.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_PreferNone_SingleLine_Maintain.txt
@@ -1,0 +1,69 @@
+~~ ifStatement.useBraces: preferNone, ifStatement.nextControlFlowPosition: maintain, preferSingleLine: true ~~
+== should format if-else with preferNone, preferSingleLine, and maintain ==
+if (true)
+  a;
+else if (true)
+  b;
+
+[expect]
+if (true)
+    a;
+else if (true)
+    b;
+
+== should handle nested conditions ==
+if (condition1)
+  statement1();
+else if (condition2)
+  statement2();
+else
+  statement3();
+
+[expect]
+if (condition1)
+    statement1();
+else if (condition2)
+    statement2();
+else
+    statement3();
+
+== should keep braces when multiple statements but remove for single ==
+if (true) {
+  a;
+  b;
+} else if (true) {
+  c;
+}
+
+[expect]
+if (true) {
+    a;
+    b;
+} else if (true)
+    c;
+
+== should keep braces for declarations ==
+if (true) {
+  const x = 1;
+} else if (true) {
+  let y = 2;
+}
+
+[expect]
+if (true) {
+    const x = 1;
+} else if (true) {
+    let y = 2;
+}
+
+== should maintain control flow position ==
+if (condition1)
+  statement1();
+else if (condition2)
+  statement2();
+
+[expect]
+if (condition1)
+    statement1();
+else if (condition2)
+    statement2();

--- a/tests/specs/statements/ifStatement/IfStatement_SimpleStatementPositioning_Core.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_SimpleStatementPositioning_Core.txt
@@ -1,0 +1,86 @@
+~~ ifStatement.singleBodyPosition: nextLine, ifStatement.useBraces: maintain ~~
+== should force non-braced statements to new line with nextLine ==
+if (condition) statement();
+
+[expect]
+if (condition)
+    statement();
+
+== should force else statements to new line with nextLine ==
+if (condition) stmt1();
+else stmt2();
+
+[expect]
+if (condition)
+    stmt1();
+else
+    stmt2();
+
+== should not affect braced blocks with nextLine (BracePosition controls) ==
+if (condition) {
+    statement();
+}
+
+[expect]
+if (condition) {
+    statement();
+}
+
+== should not affect braced else blocks with nextLine ==
+if (condition) {
+    stmt1();
+} else {
+    stmt2();
+}
+
+[expect]
+if (condition) {
+    stmt1();
+} else {
+    stmt2();
+}
+
+== should handle mixed braced and non-braced with nextLine ==
+if (condition) {
+    stmt1();
+} else stmt2();
+
+[expect]
+if (condition) {
+    stmt1();
+} else
+    stmt2();
+
+== should handle nested if statements with nextLine ==
+if (condition1) if (condition2) statement();
+
+[expect]
+if (condition1)
+    if (condition2)
+        statement();
+
+== should handle complex expressions with nextLine ==
+if (condition) console.log("message");
+
+[expect]
+if (condition)
+    console.log("message");
+
+== should handle return statements with nextLine ==
+if (condition) return value;
+
+[expect]
+if (condition)
+    return value;
+
+== should handle multiple non-braced statements (via block) ==
+if (condition) {
+    stmt1();
+    stmt2();
+}
+
+[expect]
+if (condition) {
+    stmt1();
+    stmt2();
+}

--- a/tests/specs/statements/ifStatement/IfStatement_SimpleStatementPositioning_WhenNeeded.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_SimpleStatementPositioning_WhenNeeded.txt
@@ -1,0 +1,91 @@
+~~ ifStatement.singleBodyPosition: nextLine, ifStatement.useBraces: whenNeeded ~~
+== should handle empty statements correctly ==
+if (condition) ;
+
+[expect]
+if (condition);
+
+== should force new line with whenNeeded - simple expression ==
+if (condition) doSomething();
+
+[expect]
+if (condition)
+    doSomething();
+
+== should force new line with whenNeeded - else clause ==
+if (condition) doFirst();
+else doSecond();
+
+[expect]
+if (condition)
+    doFirst();
+else
+    doSecond();
+
+== should keep braces when syntactically needed with nextLine ==
+if (condition) { const x = 1; }
+
+[expect]
+if (condition) {
+    const x = 1;
+}
+
+== should not add braces for await expressions with nextLine ==
+if (condition) await doSomething();
+
+[expect]
+if (condition)
+    await doSomething();
+
+== should keep braces for function declarations with nextLine ==
+if (condition) function test() { return 1; }
+
+[expect]
+if (condition) {
+    function test() {
+        return 1;
+    }
+}
+
+== should handle mixed scenarios with whenNeeded ==
+if (condition1) { const x = 1; }
+else if (condition2) doSomething();
+else { await doAsync(); }
+
+[expect]
+if (condition1) {
+    const x = 1;
+} else if (condition2)
+    doSomething();
+else
+    await doAsync();
+
+== should handle dangling else with nextLine - nested if with else ==
+if (condition1) if (condition2) doSomething(); else doOther();
+
+[expect]
+if (condition1)
+    if (condition2)
+        doSomething();
+    else
+        doOther();
+
+== should handle triple nested if statements ==
+if (a) if (b) if(c) d;
+
+[expect]
+if (a)
+    if (b)
+        if (c)
+            d;
+
+== should handle else-if chain ==
+if (a) x; else if (b) y; else if (c) z;
+
+[expect]
+if (a)
+    x;
+else if (b)
+    y;
+else if (c)
+    z;

--- a/tests/specs/statements/ifStatement/IfStatement_UseBraces_Maintain_Nested.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_UseBraces_Maintain_Nested.txt
@@ -1,0 +1,40 @@
+~~ ifStatement.useBraces: maintain ~~
+== should not add braces for triple nested if statements ==
+if (a) if (b) if (c) statement();
+
+[expect]
+if (a) if (b) if (c) statement();
+
+== should maintain nested if with mixed braces ==
+if (a) if (b) if (c) { statement(); }
+
+[expect]
+if (a) if (b) if (c) { statement(); }
+
+== should handle deeply nested (quadruple) ==
+if (a) if (b) if (c) if (d) e;
+
+[expect]
+if (a) if (b) if (c) if (d) e;
+
+== should maintain comments in nested if statements ==
+if (a) // comment
+  if (b) if (c) statement();
+
+[expect]
+if (a) // comment
+    if (b) if (c) statement();
+
+== should maintain nested if-else ==
+if (a) if (b) x; else y;
+
+[expect]
+if (a)
+    if (b) x;
+    else y;
+
+== should maintain nested with braces on outer only ==
+if (a) { if (b) if (c) statement(); }
+
+[expect]
+if (a) { if (b) if (c) statement(); }

--- a/tests/specs/statements/ifStatement/IfStatement_UseBraces_OnlyNeeded.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_UseBraces_OnlyNeeded.txt
@@ -1,0 +1,82 @@
+~~ ifStatement.useBraces: whenNeeded ~~
+== should only add braces when syntactically necessary ==
+if (condition)
+  doSomething();
+
+[expect]
+if (condition)
+    doSomething();
+
+== should keep braces for empty block ==
+if (condition) {
+}
+
+[expect]
+if (condition) {
+}
+
+== should keep braces for multiple statements ==
+if (condition) {
+  doSomething();
+  doAnotherThing();
+}
+
+[expect]
+if (condition) {
+    doSomething();
+    doAnotherThing();
+}
+
+== should keep braces for variable declarations ==
+if (condition) {
+  const value = 42;
+}
+
+[expect]
+if (condition) {
+    const value = 42;
+}
+
+== should keep braces for let declarations ==
+if (condition) {
+  let value = 42;
+}
+
+[expect]
+if (condition) {
+    let value = 42;
+}
+
+== should keep braces for class declarations ==
+if (condition) {
+  class MyClass {}
+}
+
+[expect]
+if (condition) {
+    class MyClass {}
+}
+
+== should keep braces for function declarations ==
+if (condition) {
+  function myFunc() {}
+}
+
+[expect]
+if (condition) {
+    function myFunc() {}
+}
+
+== should keep braces for single function declaration ==
+if (condition) {
+  function myFunc() {
+    return 42;
+  }
+}
+
+[expect]
+if (condition) {
+    function myFunc() {
+        return 42;
+    }
+}

--- a/tests/specs/statements/ifStatement/IfStatement_UseBraces_PreferNone_Nested.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_UseBraces_PreferNone_Nested.txt
@@ -1,0 +1,31 @@
+~~ ifStatement.useBraces: preferNone, preferSingleLine: true ~~
+== should remove braces from triple nested if statements ==
+if (a) { if (b) { if (c) { statement(); } } }
+
+[expect]
+if (a) if (b) if (c) statement();
+
+== should keep braces for readability when comments are present ==
+if (a) {
+    // comment
+    if (b) if (c) statement();
+}
+
+[expect]
+if (a) {
+    // comment
+    if (b) if (c) statement();
+}
+
+== should remove braces from deeply nested (quadruple) ==
+if (a) { if (b) { if (c) { if (d) { e; } } } }
+
+[expect]
+if (a) if (b) if (c) if (d) e;
+
+== should handle mixed nesting with declarations ==
+if (a) { const x = 1; } else if (b) if (c) statement();
+
+[expect]
+if (a) { const x = 1; }
+else if (b) if (c) statement();

--- a/tests/specs/statements/ifStatement/IfStatement_UseBraces_PreferNone_NoElse.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_UseBraces_PreferNone_NoElse.txt
@@ -65,6 +65,22 @@ if (true) {
     // 1
 }
 
+== should keep braces when header wraps ==
+if (
+    longConditionA
+    && longConditionB
+) {
+    a;
+}
+
+[expect]
+if (
+    longConditionA
+    && longConditionB
+) {
+    a;
+}
+
 == should handle trailing comments ==
 if(true){
 } // 1

--- a/tests/specs/statements/ifStatement/IfStatement_UseBraces_WhenFormattedMultiLine.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_UseBraces_WhenFormattedMultiLine.txt
@@ -1,0 +1,157 @@
+~~ lineWidth: 40, ifStatement.useBraces: whenFormattedMultiLine ~~
+== should not add braces for single line statement ==
+if (condition) doSomething();
+
+[expect]
+if (condition) doSomething();
+
+== should add braces when statement body wraps across multiple lines ==
+if (condition) callWithManyArguments(argumentOne, argumentTwo, argumentThree, argumentFour, argumentFive);
+
+[expect]
+if (condition) {
+    callWithManyArguments(
+        argumentOne,
+        argumentTwo,
+        argumentThree,
+        argumentFour,
+        argumentFive,
+    );
+}
+
+== should keep braces off when only the condition wraps ==
+if (someVeryLongConditionThatExceedsWidth)
+  doSomething();
+
+[expect]
+if (someVeryLongConditionThatExceedsWidth)
+    doSomething();
+
+== should handle if-else chain ==
+if (shortCondition) shortStatement();
+else if (anotherVeryLongConditionThatExceedsTheLineWidth) doSomething();
+else doAnotherThing();
+
+[expect]
+if (shortCondition) shortStatement();
+else if (
+    anotherVeryLongConditionThatExceedsTheLineWidth
+) doSomething();
+else doAnotherThing();
+
+== should keep braces for already multi-line content ==
+if (condition) {
+  doSomething();
+  doAnotherThing();
+}
+
+[expect]
+if (condition) {
+    doSomething();
+    doAnotherThing();
+}
+
+== should handle empty blocks ==
+if (condition) {
+}
+
+[expect]
+if (condition) {
+}
+
+== should remove braces when header wraps but body stays single line ==
+if (
+    longConditionA
+    && longConditionB
+) {
+  doSomething();
+}
+
+[expect]
+if (
+    longConditionA
+    && longConditionB
+)
+    doSomething();
+
+== should handle declarations that would be multi-line ==
+if (condition) { const veryLongVariableNameThatExceedsWidth = 42; }
+
+[expect]
+if (condition) {
+    const veryLongVariableNameThatExceedsWidth =
+        42;
+}
+
+== should preserve single line when everything fits ==
+if (short) brief();
+else if (also) quick();
+else final();
+
+[expect]
+if (short) brief();
+else if (also) quick();
+else final();
+
+== should add braces when else body wraps across multiple lines ==
+if (first)
+  doFirst();
+else doSecondWithManyArguments(argumentOne, argumentTwo, argumentThree, argumentFour, argumentFive);
+
+[expect]
+if (first)
+    doFirst();
+else {
+    doSecondWithManyArguments(
+        argumentOne,
+        argumentTwo,
+        argumentThree,
+        argumentFour,
+        argumentFive,
+    );
+}
+
+== should add braces when await expression wraps across multiple lines ==
+if (shouldAwait)
+  await doAsyncWork(argumentOne, argumentTwo, argumentThree, argumentFour, argumentFive);
+
+[expect]
+if (shouldAwait) {
+    await doAsyncWork(
+        argumentOne,
+        argumentTwo,
+        argumentThree,
+        argumentFour,
+        argumentFive,
+    );
+}
+
+== should remove braces when body fits on single line ==
+if (short) {
+  brief();
+} else if (also) {
+  quick();
+} else
+  final();
+
+[expect]
+if (short)
+    brief();
+else if (also)
+    quick();
+else
+    final();
+
+== should handle triple nested if statements ==
+if (a) if (b) if(c) d;
+
+[expect]
+if (a) if (b) if (c) d;
+
+== should handle else-if chain ==
+if (a) x; else if (b) y; else if (c) z;
+
+[expect]
+if (a) x;
+else if (b) y;
+else if (c) z;

--- a/tests/specs/statements/ifStatement/IfStatement_UseBraces_WhenNeeded.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_UseBraces_WhenNeeded.txt
@@ -1,0 +1,129 @@
+~~ ifStatement.useBraces: whenNeeded ~~
+== should not add braces for single statement ==
+if (condition)
+  doSomething();
+
+[expect]
+if (condition)
+    doSomething();
+
+== should keep braces for empty block ==
+if (condition) {
+}
+
+[expect]
+if (condition) {
+}
+
+== should keep braces for multiple statements ==
+if (condition) {
+  doSomething();
+  doAnotherThing();
+}
+
+[expect]
+if (condition) {
+    doSomething();
+    doAnotherThing();
+}
+
+== should keep braces for declarations ==
+if (condition) {
+  const value = 42;
+}
+
+[expect]
+if (condition) {
+    const value = 42;
+}
+
+== should handle if-else chain independently ==
+if (condition1)
+  statement1();
+else if (condition2) {
+  const value = 42;
+}
+else
+  statement3();
+
+[expect]
+if (condition1)
+    statement1();
+else if (condition2) {
+    const value = 42;
+} else
+    statement3();
+
+== should remove unnecessary braces from single expressions ==
+if (condition) {
+  doSomething();
+}
+
+[expect]
+if (condition)
+    doSomething();
+
+== should handle nested if statements ==
+if (condition1)
+  if (condition2)
+    doSomething();
+
+[expect]
+if (condition1)
+    if (condition2)
+        doSomething();
+
+== should keep braces for function declarations ==
+if (condition) {
+  function innerFunc() {
+    return 42;
+  }
+}
+
+[expect]
+if (condition) {
+    function innerFunc() {
+        return 42;
+    }
+}
+
+== should remove braces when header wraps ==
+if (
+    longConditionA
+    && longConditionB
+) {
+  doSomething();
+}
+
+[expect]
+if (
+    longConditionA
+    && longConditionB
+)
+    doSomething();
+
+== should keep braces when syntactically required ==
+if (condition) {
+  if (true) f()
+} else
+  g();
+
+[expect]
+if (condition) {
+    if (true) f();
+} else
+    g();
+
+== should handle triple nested if statements ==
+if (a) if (b) if(c) d;
+
+[expect]
+if (a) if (b) if (c) d;
+
+== should handle else-if chain ==
+if (a) x; else if (b) y; else if (c) z;
+
+[expect]
+if (a) x;
+else if (b) y;
+else if (c) z;

--- a/tests/specs/statements/ifStatement/IfStatement_UseBraces_WhenNotSingleLine.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_UseBraces_WhenNotSingleLine.txt
@@ -64,3 +64,17 @@ if (
 ) { // testing this out
     logger;
 }
+
+== should handle triple nested if statements ==
+if (a) if (b) if(c) d;
+
+[expect]
+if (a) if (b) if (c) d;
+
+== should handle else-if chain ==
+if (a) x; else if (b) y; else if (c) z;
+
+[expect]
+if (a) x;
+else if (b) y;
+else if (c) z;

--- a/tests/specs/statements/ifStatement/IfStatement_WhenFormattedMultiLine_NextLine.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_WhenFormattedMultiLine_NextLine.txt
@@ -1,0 +1,22 @@
+~~ ifStatement.useBraces: whenFormattedMultiLine, ifStatement.singleBodyPosition: nextLine, lineWidth: 40 ~~
+== should handle triple nested if statements ==
+if (a) if (b) if(c) d;
+
+[expect]
+if (a) {
+    if (b) {
+        if (c)
+            d;
+    }
+}
+
+== should handle else-if chain ==
+if (a) x; else if (b) y; else if (c) z;
+
+[expect]
+if (a)
+    x;
+else if (b)
+    y;
+else if (c)
+    z;

--- a/tests/specs/statements/ifStatement/IfStatement_WhenNotSingleLine_NextLine.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_WhenNotSingleLine_NextLine.txt
@@ -1,0 +1,24 @@
+~~ ifStatement.useBraces: whenNotSingleLine, ifStatement.singleBodyPosition: nextLine, lineWidth: 40 ~~
+== should handle triple nested if statements ==
+if (a) if (b) if(c) d;
+
+[expect]
+if (a) {
+    if (b) {
+        if (c) {
+            d;
+        }
+    }
+}
+
+== should handle else-if chain ==
+if (a) x; else if (b) y; else if (c) z;
+
+[expect]
+if (a) {
+    x;
+} else if (b) {
+    y;
+} else if (c) {
+    z;
+}

--- a/tests/specs/statements/whileStatement/WhileStatement_UseBraces_WhenNeeded.txt
+++ b/tests/specs/statements/whileStatement/WhileStatement_UseBraces_WhenNeeded.txt
@@ -1,0 +1,10 @@
+~~ whileStatement.useBraces: whenNeeded ~~
+== should keep braces for declaration bodies ==
+while (true) {
+    const value = 1;
+}
+
+[expect]
+while (true) {
+    const value = 1;
+}


### PR DESCRIPTION
This commit introduces two new brace usage modes for control flow statements: whenNeeded and whenFormattedMultiLine, providing more granular control over brace insertion.

## Added enum variants

**UseBraces::WhenNeeded**: Only uses braces when syntactically required (empty blocks, declarations, multiple statements, or to avoid dangling else ambiguity)

**UseBraces::WhenFormattedMultiLine**: Uses braces when the formatted body spans multiple lines, removing them for single-line statements

## Implementation changes

- Replaced force_use_braces_for_stmt with more flexible helper functions (get_use_braces_for_node, get_use_braces_for_stmt)
- Added contains_dangling_if to detect dangling else problems
- Added use_braces_for_then and use_braces_for_else to enforce braces when required for correctness (declarations, dangling else)
- Updated gen_conditional_brace_body to support new brace modes
- Updated gen_if_stmt to intelligently apply braces based on context

## Test coverage

- Added 13 test files covering whenNeeded and whenFormattedMultiLine modes
- All 660 spec tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>