### PR TITLE
feat: add nextLineExceptAfterBrace control flow position option

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -199,6 +199,9 @@
       }, {
         "const": "nextLine",
         "description": "Forces the next control flow to be on the next line."
+      }, {
+        "const": "nextLineExceptAfterBrace",
+        "description": "Forces the next control flow to be on the next line, except when preceded by a brace."
       }]
     },
     "trailingCommas": {

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -119,9 +119,17 @@ pub enum NextControlFlowPosition {
   SameLine,
   /// Forces the next control flow to be on the next line.
   NextLine,
+  /// Forces the next control flow to be on the next line except when it appears after a closing brace.
+  NextLineExceptAfterBrace,
 }
 
-generate_str_to_from![NextControlFlowPosition, [Maintain, "maintain"], [SameLine, "sameLine"], [NextLine, "nextLine"]];
+generate_str_to_from![
+  NextControlFlowPosition,
+  [Maintain, "maintain"],
+  [SameLine, "sameLine"],
+  [NextLine, "nextLine"],
+  [NextLineExceptAfterBrace, "nextLineExceptAfterBrace"]
+];
 
 /// Where to place the operator for expressions that span multiple lines.
 #[derive(Debug, Clone, PartialEq, Copy, Serialize, Deserialize)]

--- a/tests/specs/statements/doWhileStatement/DoWhileStatement_NextControlFlowPosition_NextLineExceptAfterBrace.txt
+++ b/tests/specs/statements/doWhileStatement/DoWhileStatement_NextControlFlowPosition_NextLineExceptAfterBrace.txt
@@ -1,0 +1,141 @@
+~~ doWhileStatement.nextControlFlowPosition: nextLineExceptAfterBrace ~~
+== should keep while on same line after brace ==
+do {
+    doSomething();
+} while (condition);
+
+[expect]
+do {
+    doSomething();
+} while (condition);
+
+== should use newline before while for non-block body ==
+do doSomething(); while (condition);
+
+[expect]
+do doSomething();
+while (condition);
+
+== should keep while on same line after brace even with trailing comment ==
+do {
+    doSomething();
+} // trailing comment
+while (condition);
+
+[expect]
+do {
+    doSomething();
+} // trailing comment
+while (condition);
+
+== should use newline before while when body lacks braces despite trailing comment ==
+do doSomething(); // trailing comment
+while (condition);
+
+[expect]
+do doSomething(); // trailing comment
+while (condition);
+
+== should handle block comment after closing brace ==
+do {
+    code();
+} /* block comment */ while (condition);
+
+[expect]
+do {
+    code();
+} /* block comment */
+while (condition);
+
+== should handle empty block with trailing comment ==
+do {} // comment
+while (condition);
+
+[expect]
+do {} // comment
+while (condition);
+
+== should handle multi-line block comment ==
+do {
+    code();
+} /*
+ * multi-line
+ * comment
+ */
+while (condition);
+
+[expect]
+do {
+    code();
+} /*
+ * multi-line
+ * comment
+ */
+while (condition);
+
+== should handle nested structures with trailing comments ==
+do {
+    if (x) {
+        code();
+    } // inner comment
+} // outer comment
+while (condition);
+
+[expect]
+do {
+    if (x) {
+        code();
+    } // inner comment
+} // outer comment
+while (condition);
+
+== should handle empty comment with no text ==
+do {
+    code();
+} //
+while (condition);
+
+[expect]
+do {
+    code();
+} //
+while (condition);
+
+== should handle comment with only whitespace ==
+do {
+    code();
+} //
+while (condition);
+
+[expect]
+do {
+    code();
+} //
+while (condition);
+
+== should handle pathological all-on-one-line case ==
+do {} /* comment */ while (condition);
+
+[expect]
+do {} /* comment */
+while (condition);
+
+== should handle very deeply nested structures ==
+do {
+    if (a) {
+        while (b) {
+            code();
+        } // inner
+    } // middle
+} // outer
+while (condition);
+
+[expect]
+do {
+    if (a) {
+        while (b) {
+            code();
+        } // inner
+    } // middle
+} // outer
+while (condition);

--- a/tests/specs/statements/doWhileStatement/DoWhileStatement_NextControlFlowPosition_NextLineExceptAfterBrace_Asi.txt
+++ b/tests/specs/statements/doWhileStatement/DoWhileStatement_NextControlFlowPosition_NextLineExceptAfterBrace_Asi.txt
@@ -1,0 +1,49 @@
+~~ semiColons: asi, doWhileStatement.nextControlFlowPosition: nextLineExceptAfterBrace ~~
+== should keep while on same line after brace with ASI ==
+do {
+    doSomething();
+} while (condition);
+
+[expect]
+do {
+    doSomething()
+} while (condition)
+
+== should keep while on same line after brace with trailing comment under ASI ==
+do {
+    doSomething()
+} // trailing comment
+while (condition)
+
+[expect]
+do {
+    doSomething()
+} // trailing comment
+while (condition)
+
+== should use newline before while when body lacks braces under ASI with trailing comment ==
+do doSomething() // trailing comment
+while (condition)
+
+[expect]
+do doSomething() // trailing comment
+while (condition)
+
+== should handle empty comment with no text under ASI ==
+do {
+    code()
+} //
+while (condition)
+
+[expect]
+do {
+    code()
+} //
+while (condition)
+
+== should handle pathological all-on-one-line case with ASI ==
+do {} /* comment */ while (condition)
+
+[expect]
+do {} /* comment */
+while (condition)

--- a/tests/specs/statements/ifStatement/IfStatement_NextControlFlowPosition_Maintain_PreferNone.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_NextControlFlowPosition_Maintain_PreferNone.txt
@@ -1,0 +1,30 @@
+~~ ifStatement.useBraces: preferNone, ifStatement.nextControlFlowPosition: maintain ~~
+== should move else to next line when braces are removed ==
+if (condition) {
+    doSomething();
+} else {
+    handleElse();
+}
+
+[expect]
+if (condition)
+    doSomething();
+else
+    handleElse();
+
+== should keep else-if chain readable after brace removal ==
+if (first) {
+    handleFirst();
+} else if (second) {
+    handleSecond();
+} else {
+    handleFallback();
+}
+
+[expect]
+if (first)
+    handleFirst();
+else if (second)
+    handleSecond();
+else
+    handleFallback();

--- a/tests/specs/statements/ifStatement/IfStatement_NextControlFlowPosition_NextLineExceptAfterBrace.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_NextControlFlowPosition_NextLineExceptAfterBrace.txt
@@ -1,0 +1,349 @@
+~~ ifStatement.useBraces: preferNone, ifStatement.nextControlFlowPosition: nextLineExceptAfterBrace ~~
+== should move else to next line when braces removed ==
+if (value) {
+    handle();
+} else {
+    fallback();
+}
+
+[expect]
+if (value)
+    handle();
+else
+    fallback();
+
+== should keep else on same line when braces remain ==
+if (value) {
+    handle();
+} else {
+    fallback();
+    more();
+}
+
+[expect]
+if (value)
+    handle();
+else {
+    fallback();
+    more();
+}
+
+== should handle trailing comment before else ==
+if (x) {
+    f();
+} // test
+else {
+    g();
+}
+
+[expect]
+if (x)
+    f();
+// test
+else
+    g();
+
+== should handle else-if chain ==
+if (first) {
+    handleFirst();
+} else if (second) {
+    handleSecond();
+} else {
+    handleFallback();
+}
+
+[expect]
+if (first)
+    handleFirst();
+else if (second)
+    handleSecond();
+else
+    handleFallback();
+
+== should handle else-if chain with trailing comments ==
+if (x) {
+    f();
+} // comment1
+else if (y) {
+    g();
+} // comment2
+else {
+    h();
+}
+
+[expect]
+if (x)
+    f();
+// comment1
+else if (y)
+    g();
+// comment2
+else
+    h();
+
+== should handle block comment before else ==
+if (x) {
+    f();
+} /* block comment */ else {
+    g();
+}
+
+[expect]
+if (x)
+    f();
+/* block comment */ else
+    g();
+
+== should handle empty if block with trailing comment ==
+if (x) {} // comment
+else {
+    g();
+}
+
+[expect]
+if (x) {} // comment
+else {
+    g();
+}
+
+== should handle comment after else block ==
+if (x) {
+    f();
+} else {
+    g();
+} // final comment
+
+[expect]
+if (x)
+    f();
+else
+    g(); // final comment
+
+== should handle nested structures with multiple trailing comments ==
+if (outer) {
+    if (inner) {
+        code();
+    } // inner comment
+} // outer comment
+else {
+    fallback();
+}
+
+[expect]
+if (outer) {
+    if (inner)
+        code(); // inner comment
+} // outer comment
+else {
+    fallback();
+}
+
+== should handle multi-line block comment before else ==
+if (x) {
+    f();
+} /*
+ * multi-line
+ * comment
+ */
+else {
+    g();
+}
+
+[expect]
+if (x)
+    f();
+/*
+ * multi-line
+ * comment
+ */
+else
+    g();
+
+== should handle comments with else-if without braces ==
+if (x)
+    single(); // comment
+else if (y)
+    other();
+
+[expect]
+if (x)
+    single(); // comment
+else if (y)
+    other();
+
+== should handle block comment with braces kept ==
+if (x) {
+    f();
+    g();
+} /* block */
+else {
+    h();
+}
+
+[expect]
+if (x) {
+    f();
+    g();
+} /* block */
+else {
+    h();
+}
+
+== should handle empty comment with no text ==
+if (x) {
+    f();
+} //
+else {
+    g();
+}
+
+[expect]
+if (x)
+    f();
+//
+else
+    g();
+
+== should handle comment with only whitespace ==
+if (x) {
+    f();
+} //
+else {
+    g();
+}
+
+[expect]
+if (x)
+    f();
+//
+else
+    g();
+
+== should handle pathological all-on-one-line case ==
+if (a) {} /* c1 */ else if (b) {} /* c2 */ else {}
+
+[expect]
+if (a) {} /* c1 */
+else if (b) {} /* c2 */
+else {}
+
+== should handle very deeply nested structures with comments ==
+if (outer) {
+    if (mid) {
+        if (inner) {
+            code();
+        } // level3
+    } // level2
+} // level1
+else {
+    fallback();
+}
+
+[expect]
+if (outer) {
+    if (mid) {
+        if (inner)
+            code(); // level3
+    } // level2
+} // level1
+else {
+    fallback();
+}
+
+== should keep empty if block compact with trailing comment ==
+if (x) {} // empty
+else {
+    g();
+}
+
+[expect]
+if (x) {} // empty
+else {
+    g();
+}
+
+== should keep non-empty if block compact without trailing comment ==
+if (x) {
+    f();
+}
+else {
+    g();
+}
+
+[expect]
+if (x)
+    f();
+else
+    g();
+
+== should keep non-empty if block compact with trailing comment ==
+if (x) {
+    f();
+} // done
+else {
+    g();
+}
+
+[expect]
+if (x)
+    f();
+// done
+else
+    g();
+
+== should keep empty else block compact with trailing comment ==
+if (x) {
+    f();
+} else {} // empty else
+
+[expect]
+if (x)
+    f();
+else {} // empty else
+
+== should keep non-empty else block compact ==
+if (x) {
+    f();
+} else {
+    g();
+}
+
+[expect]
+if (x)
+    f();
+else
+    g();
+
+== should handle mixed empty and non-empty blocks with comments ==
+if (x) {} // empty if
+else {
+    g();
+}
+
+[expect]
+if (x) {} // empty if
+else {
+    g();
+}
+
+== should handle all empty if-else with comments ==
+if (x) {} // x
+else {} // y
+
+[expect]
+if (x) {} // x
+else {} // y
+
+== should handle empty if with braces kept and trailing comment ==
+if (x) {
+    f();
+    g();
+} // multi
+else {} // empty
+
+[expect]
+if (x) {
+    f();
+    g();
+} // multi
+else {} // empty

--- a/tests/specs/statements/ifStatement/IfStatement_NextControlFlowPosition_NextLineExceptAfterBrace_Asi.txt
+++ b/tests/specs/statements/ifStatement/IfStatement_NextControlFlowPosition_NextLineExceptAfterBrace_Asi.txt
@@ -1,0 +1,51 @@
+~~ semiColons: asi, ifStatement.useBraces: preferNone, ifStatement.nextControlFlowPosition: nextLineExceptAfterBrace ~~
+== should handle trailing comment before else with ASI ==
+if (x) {
+    f()
+} // test
+else {
+    g()
+}
+
+[expect]
+if (x)
+    f()
+// test
+else
+    g()
+
+== should handle else-if chain with trailing comments under ASI ==
+if (x) {
+    f()
+} // comment1
+else if (y) {
+    g()
+} // comment2
+else {
+    h()
+}
+
+[expect]
+if (x)
+    f()
+// comment1
+else if (y)
+    g()
+// comment2
+else
+    h()
+
+== should handle block comment before else with ASI ==
+if (x) {
+    f()
+} /* block comment */
+else {
+    g()
+}
+
+[expect]
+if (x)
+    f()
+/* block comment */
+else
+    g()

--- a/tests/specs/statements/tryStatement/TryStatement_All.txt
+++ b/tests/specs/statements/tryStatement/TryStatement_All.txt
@@ -56,18 +56,14 @@ try {
     test;
 } catch {}
 
-== should expand to try block being on one line when all are on one line ==
+== should keep empty try block compact when all are on one line ==
 try {} catch {}
 
 [expect]
-try {
-} catch {}
+try {} catch {}
 
-== should expand to try block being on one line when all are on one line ==
+== should keep all empty blocks compact when all are on one line ==
 try {} catch {} finally {}
 
 [expect]
-try {
-} catch {
-} finally {
-}
+try {} catch {} finally {}

--- a/tests/specs/statements/tryStatement/TryStatement_NextControlFlowPosition_Maintain.txt
+++ b/tests/specs/statements/tryStatement/TryStatement_NextControlFlowPosition_Maintain.txt
@@ -54,3 +54,51 @@ catch {
 }
 finally {
 }
+
+== should maintain same line after brace with trailing comment ==
+try {
+    code();
+} // comment
+catch (e) {
+    handle();
+}
+
+[expect]
+try {
+    code();
+} // comment
+catch (e) {
+    handle();
+}
+
+== should maintain new line when comment before catch ==
+try {
+    code();
+}
+// comment before catch
+catch (e) {
+    handle();
+}
+
+[expect]
+try {
+    code();
+}
+// comment before catch
+catch (e) {
+    handle();
+}
+
+== should maintain position with block comment ==
+try {
+    code();
+} /* block */ catch (e) {
+    handle();
+}
+
+[expect]
+try {
+    code();
+} /* block */ catch (e) {
+    handle();
+}

--- a/tests/specs/statements/tryStatement/TryStatement_NextControlFlowPosition_NextLine.txt
+++ b/tests/specs/statements/tryStatement/TryStatement_NextControlFlowPosition_NextLine.txt
@@ -15,3 +15,35 @@ catch {
 }
 finally {
 }
+
+== should always use newline even with trailing comment ==
+try {
+    code();
+} // comment
+catch (e) {
+    handle();
+}
+
+[expect]
+try {
+    code();
+} // comment
+catch (e) {
+    handle();
+}
+
+== should always use newline with block comment ==
+try {
+    code();
+} /* block */
+catch (e) {
+    handle();
+}
+
+[expect]
+try {
+    code();
+} /* block */
+catch (e) {
+    handle();
+}

--- a/tests/specs/statements/tryStatement/TryStatement_NextControlFlowPosition_NextLineExceptAfterBrace.txt
+++ b/tests/specs/statements/tryStatement/TryStatement_NextControlFlowPosition_NextLineExceptAfterBrace.txt
@@ -1,0 +1,407 @@
+~~ tryStatement.nextControlFlowPosition: nextLineExceptAfterBrace ~~
+== should keep catch on same line after brace ==
+try {
+    doSomething();
+} catch (err) {
+    handleError();
+}
+
+[expect]
+try {
+    doSomething();
+} catch (err) {
+    handleError();
+}
+
+== should keep catch on new line when trailing comment present ==
+try {
+    run();
+} // trailing comment
+catch (err) {
+    handle(err);
+}
+
+[expect]
+try {
+    run();
+} // trailing comment
+catch (err) {
+    handle(err);
+}
+
+== should keep finally on new line when trailing comment present ==
+try {
+    run();
+} // trailing comment
+finally {
+    cleanup();
+}
+
+[expect]
+try {
+    run();
+} // trailing comment
+finally {
+    cleanup();
+}
+
+== should keep finally on same line in try-finally ==
+try {
+    doSomething();
+} finally {
+    cleanup();
+}
+
+[expect]
+try {
+    doSomething();
+} finally {
+    cleanup();
+}
+
+== should handle try-catch-finally ==
+try {
+    doSomething();
+} catch (err) {
+    handleError();
+} finally {
+    cleanup();
+}
+
+[expect]
+try {
+    doSomething();
+} catch (err) {
+    handleError();
+} finally {
+    cleanup();
+}
+
+== should handle try-catch-finally with trailing comments ==
+try {
+    doSomething();
+} // comment1
+catch (err) {
+    handleError();
+} // comment2
+finally {
+    cleanup();
+}
+
+[expect]
+try {
+    doSomething();
+} // comment1
+catch (err) {
+    handleError();
+} // comment2
+finally {
+    cleanup();
+}
+
+== should handle block comment after closing brace ==
+try {
+    code();
+} /* block comment */
+catch (e) {
+    handle();
+}
+
+[expect]
+try {
+    code();
+} /* block comment */
+catch (e) {
+    handle();
+}
+
+== should handle empty blocks with trailing comments ==
+try {} // comment
+catch (e) {}
+
+[expect]
+try {} // comment
+catch (e) {}
+
+== should handle comment after finally block ==
+try {
+    code();
+} catch (e) {
+    handle();
+} finally {
+    cleanup();
+} // final comment
+
+[expect]
+try {
+    code();
+} catch (e) {
+    handle();
+} finally {
+    cleanup();
+} // final comment
+
+== should handle nested structures with multiple trailing comments ==
+try {
+    if (x) {
+        code();
+    } // inner comment
+} // outer comment
+catch (e) {
+    handle();
+}
+
+[expect]
+try {
+    if (x) {
+        code();
+    } // inner comment
+} // outer comment
+catch (e) {
+    handle();
+}
+
+== should handle multi-line block comments ==
+try {
+    code();
+} /*
+ * multi-line
+ * comment
+ */
+catch (e) {
+    handle();
+}
+
+[expect]
+try {
+    code();
+} /*
+ * multi-line
+ * comment
+ */
+catch (e) {
+    handle();
+}
+
+== should keep catch on same line when no trailing comment ==
+try {
+    run();
+}
+catch (err) {
+    handleWithoutBraces();
+}
+
+[expect]
+try {
+    run();
+} catch (err) {
+    handleWithoutBraces();
+}
+
+== should handle empty comment with no text ==
+try {
+    code();
+} //
+catch (e) {
+    handle();
+}
+
+[expect]
+try {
+    code();
+} //
+catch (e) {
+    handle();
+}
+
+== should handle comment with only whitespace ==
+try {
+    code();
+} //
+catch (e) {
+    handle();
+}
+
+[expect]
+try {
+    code();
+} //
+catch (e) {
+    handle();
+}
+
+== should handle very deeply nested structures ==
+try {
+    if (a) {
+        while (b) {
+            do {
+                code();
+            } // inner1
+            while (c); // inner2
+        } // inner3
+    } // inner4
+} // outer
+catch (e) {
+    handle();
+}
+
+[expect]
+try {
+    if (a) {
+        while (b) {
+            do {
+                code();
+            } // inner1
+            while (c); // inner2
+        } // inner3
+    } // inner4
+} // outer
+catch (e) {
+    handle();
+}
+
+== should keep empty try block compact without trailing comment ==
+try {}
+catch (e) {
+    handle();
+}
+
+[expect]
+try {} catch (e) {
+    handle();
+}
+
+== should keep empty try block compact with trailing comment ==
+try {} // empty
+catch (e) {
+    handle();
+}
+
+[expect]
+try {} // empty
+catch (e) {
+    handle();
+}
+
+== should keep non-empty try block compact without trailing comment ==
+try {
+    code();
+}
+catch (e) {
+    handle();
+}
+
+[expect]
+try {
+    code();
+} catch (e) {
+    handle();
+}
+
+== should keep non-empty try block compact with trailing comment ==
+try {
+    code();
+} // done
+catch (e) {
+    handle();
+}
+
+[expect]
+try {
+    code();
+} // done
+catch (e) {
+    handle();
+}
+
+== should keep empty catch block on same line without trailing comment ==
+try {
+    code();
+} catch (e) {}
+
+[expect]
+try {
+    code();
+} catch (e) {}
+
+== should keep empty catch block compact with trailing comment ==
+try {
+    code();
+} catch (e) {} // empty catch
+
+[expect]
+try {
+    code();
+} catch (e) {} // empty catch
+
+== should keep non-empty catch block compact ==
+try {
+    code();
+} catch (e) {
+    handle();
+}
+
+[expect]
+try {
+    code();
+} catch (e) {
+    handle();
+}
+
+== should keep empty finally block on same line without trailing comment ==
+try {
+    code();
+} catch (e) {
+    handle();
+} finally {}
+
+[expect]
+try {
+    code();
+} catch (e) {
+    handle();
+} finally {}
+
+== should keep empty finally block compact with trailing comment ==
+try {
+    code();
+} catch (e) {
+    handle();
+} finally {} // cleanup
+
+[expect]
+try {
+    code();
+} catch (e) {
+    handle();
+} finally {} // cleanup
+
+== should handle mixed empty and non-empty blocks ==
+try {} // empty try
+catch (e) {
+    handle();
+} finally {} // empty finally
+
+[expect]
+try {} // empty try
+catch (e) {
+    handle();
+} finally {} // empty finally
+
+== should keep all empty blocks compact without comments ==
+try {}
+catch (e) {}
+finally {}
+
+[expect]
+try {} catch (e) {} finally {}
+
+== should keep all empty blocks compact with comments ==
+try {} // t
+catch (e) {} // c
+finally {} // f
+
+[expect]
+try {} // t
+catch (e) {} // c
+finally {} // f

--- a/tests/specs/statements/tryStatement/TryStatement_NextControlFlowPosition_NextLineExceptAfterBrace_Asi.txt
+++ b/tests/specs/statements/tryStatement/TryStatement_NextControlFlowPosition_NextLineExceptAfterBrace_Asi.txt
@@ -1,0 +1,68 @@
+~~ semiColons: asi, tryStatement.nextControlFlowPosition: nextLineExceptAfterBrace ~~
+== should keep catch on same line with ASI ==
+try {
+    doSomething()
+} catch (err) {
+    handleError()
+}
+
+[expect]
+try {
+    doSomething()
+} catch (err) {
+    handleError()
+}
+
+== should handle trailing comment with ASI ==
+try {
+    run()
+} // trailing comment
+catch (err) {
+    handle(err)
+}
+
+[expect]
+try {
+    run()
+} // trailing comment
+catch (err) {
+    handle(err)
+}
+
+== should handle block comment with ASI ==
+try {
+    code()
+} /* block comment */
+catch (e) {
+    handle()
+}
+
+[expect]
+try {
+    code()
+} /* block comment */
+catch (e) {
+    handle()
+}
+
+== should handle try-catch-finally with trailing comments under ASI ==
+try {
+    doSomething()
+} // comment1
+catch (err) {
+    handleError()
+} // comment2
+finally {
+    cleanup()
+}
+
+[expect]
+try {
+    doSomething()
+} // comment1
+catch (err) {
+    handleError()
+} // comment2
+finally {
+    cleanup()
+}

--- a/tests/specs/statements/tryStatement/TryStatement_NextControlFlowPosition_SameLine.txt
+++ b/tests/specs/statements/tryStatement/TryStatement_NextControlFlowPosition_SameLine.txt
@@ -15,3 +15,49 @@ try {
 } catch {
 } finally {
 }
+
+== should use newline when trailing comment present ==
+try {
+    code();
+} // comment
+catch (e) {
+    handle();
+}
+
+[expect]
+try {
+    code();
+} // comment
+catch (e) {
+    handle();
+}
+
+== should keep on same line with block comment ==
+try {
+    code();
+} /* block */ catch (e) {
+    handle();
+}
+
+[expect]
+try {
+    code();
+} /* block */ catch (e) {
+    handle();
+}
+
+== should use newline when block and line comments present ==
+try {
+    work();
+} /* block */ // trailing
+catch (err) {
+    recover();
+}
+
+[expect]
+try {
+    work();
+} /* block */ // trailing
+catch (err) {
+    recover();
+}


### PR DESCRIPTION
This commit adds a new NextControlFlowPosition option that forces the next control flow (else, catch, finally, while) to be on the next line, except when it appears after a closing brace.

This is useful for consistent control flow positioning, particularly when using configurations that may remove braces conditionally. It ensures that control flow keywords appear on a new line when following non-braced statements, but remain on the same line when following braced blocks.

Options:
- `nextLineExceptAfterBrace`: Forces next control flow to new line, except when preceded by a closing brace (e.g., `} else` stays together, but `statement; else` gets separated)

Changes:
- Added NextLineExceptAfterBrace variant to NextControlFlowPosition enum
- Updated schema.json with new configuration option
- Modified gen_control_flow_separator to handle the new positioning mode
- Added handle_else_after_brace_removal helper for Maintain mode
- Added push_always_true_condition helper for brace tracking
- Updated gen_do_while_stmt to track brace presence
- Updated gen_try_stmt to track brace presence for catch/finally
- Added 4 test cases covering do-while and try-catch-finally scenarios